### PR TITLE
Add Rails section and rule around use of render and return

### DIFF
--- a/README.md
+++ b/README.md
@@ -971,7 +971,8 @@ in inheritance.
 
 ## Rails
 
-  * When using multiple `render` calls in an ActionController, always put the `return` on the next line.
+  * When immediately returning after calling `render` or `redirect_to`, put `return` on the next line,
+    not the same line.
 
     ```Ruby
       # bad


### PR DESCRIPTION
On https://github.com/airbnb/airbnb/pull/2655 , @clizzin suggested that in cases where `render` and `return` are both used in a statement in ActiveRecord, they should be on different lines. I personally prefer the `render :text => 'hello' and return` way for brevity and readability. I brought the discussion here. What do people think? Yay or nay?
