### PR TITLE
For cleaner "if"/"unless" usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,7 +466,7 @@ Never leave commented-out code in our codebase.
       end
 
       # okay
-      if !foo? || !bar?
+      if !(foo? && bar?)
         puts "baz"
       end
     ```


### PR DESCRIPTION
- "if"/"unless" modifiers on long, complex lines
- Don't make hard-to-understand "unless" conditionals
- Remove very poorly worded/exampled/confusing whitespace guidance.
