### PR TITLE
Ban ActiveRecord dynamic finder methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -977,6 +977,16 @@ in inheritance.
 
 ## Rails
 
+  * Do not use ActiveRecord dynamic finders.  They are [deprecated](http://guides.rubyonrails.org/active_record_querying.html#dynamic-finders).
+
+    ```ruby
+    # bad
+    Parties.find_by_country_and_wildness('US', 9000)
+
+    # good
+    Parties.where(:country => 'US', :wildness => 9000).first
+    ```
+
   * When immediately returning after calling `render` or `redirect_to`, put `return` on the next line,
     not the same line.
 


### PR DESCRIPTION
I was reminded by @gkoo in [this comment](https://github.com/airbnb/airbnb/pull/3114/files#r5206241) that dynamic finder methods are deprecated.  Moreover, they are lame.

Thoughts?