### PR TITLE
Change the suggestion for public, protected, and private indentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -856,8 +856,9 @@ in inheritance.
     end
     ```
 
-* Indent the `public`, `protected`, and `private` methods as much the
-  method definitions they apply to. Leave one blank line above them.
+* Indent the `public`, `protected`, and `private` methods one space
+  less than the method definitions they apply to. Leave one blank
+  line above them.
 
     ```Ruby
     class SomeClass
@@ -865,7 +866,7 @@ in inheritance.
         # ...
       end
 
-      private
+     private
       def private_method
         # ...
       end


### PR DESCRIPTION
I think that indenting these keywords one space less than the functions
they apply to leads to much cleaner code. public, protected, and private
are effectively marking off a block of code, so visually they should not
visually blend in with the code affected.