### PR TITLE
Fix 'Exceptions' formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,14 +120,14 @@ Airbnb also maintains a [JavaScript Style Guide][airbnb-javascript].
       redirect_to_alteration @reservation_alteration
     end
     ```
-    
+
 * Add a new line after conditionals, blocks, case statements, etc.
 
     ```ruby
     if robot.is_awesome?
       send_robot_present
     end
-    
+
     robot.add_trait(:human_like_intelligence)
     ```
 
@@ -870,6 +870,7 @@ in inheritance.
         # ...
       end
     end
+    ```
 
 ## Exceptions
 


### PR DESCRIPTION
Before this change, the "#exceptions" anchor tag was broken and the "Exceptions" section appeared in a code block nested under the "Classes" section.
