### PR TITLE
Make style guide in line with common practice regarding parens

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,9 +466,7 @@ Never leave commented-out code in our codebase.
     f(3 + 2) + 1
     ```
 
-**Omit parentheses** for a method call:
-
-* If the method accepts no arguments.
+**Omit parentheses** for a method call if the method accepts no arguments.
 
     ```ruby
     # bad
@@ -478,13 +476,13 @@ Never leave commented-out code in our codebase.
     nil?
     ```
 
-* If the method doesn't return a value (or we don't care about the return).
+If the method doesn't return a value (or we don't care about the return), parentheses are optional. (Especially if the arguments overflow to multiple lines, parentheses may add readability.)
 
     ```ruby
-    # bad
+    # okay
     render(:partial => 'foo')
 
-    # good
+    # okay
     render :partial => 'foo'
     ```
 


### PR DESCRIPTION
That parens are optional when the return value is not used.

@patyoon @Henry Yao  @airbnb/nerds 