### PR TITLE
Syntax highlight two code examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,7 +466,7 @@ Never leave commented-out code in our codebase.
     f(3 + 2) + 1
     ```
 
-**Omit parentheses** for a method call if the method accepts no arguments.
+* **Omit parentheses** for a method call if the method accepts no arguments.
 
     ```ruby
     # bad
@@ -476,7 +476,7 @@ Never leave commented-out code in our codebase.
     nil?
     ```
 
-If the method doesn't return a value (or we don't care about the return), parentheses are optional. (Especially if the arguments overflow to multiple lines, parentheses may add readability.)
+* If the method doesn't return a value (or we don't care about the return), parentheses are optional. (Especially if the arguments overflow to multiple lines, parentheses may add readability.)
 
     ```ruby
     # okay


### PR DESCRIPTION
Kind of a strange fix, yes, but it gets rid of this

    ```ruby