### PR TITLE
Corrected parameter & argument misnomers

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Airbnb also maintains a [JavaScript Style Guide][airbnb-javascript].
            end
     ```
 
-* Align function arguments either all on the same line or one per line.
+* Align function parameters either all on the same line or one per line.
 
     ```ruby
     # good
@@ -398,15 +398,15 @@ Never leave commented-out code in our codebase.
 
 ### Method definitions
 
-* Use `def` with parentheses when there are arguments. Omit the
-  parentheses when the method doesn't accept any arguments.
+* Use `def` with parentheses when there are parameters. Omit the
+  parentheses when the method doesn't accept any parameters.
 
      ```Ruby
      def some_method
        # body omitted
      end
 
-     def some_method_with_arguments(arg1, arg2)
+     def some_method_with_parameters(arg1, arg2)
        # body omitted
      end
      ```

--- a/README.md
+++ b/README.md
@@ -734,7 +734,7 @@ In either case:
   one-liner scripts is discouraged. Prefer long form versions such as
   `$PROGRAM_NAME`.
 
-* Use `_` for unused block parameters.
+* Use `_` for unused block arguments.
 
     ```Ruby
     # bad


### PR DESCRIPTION
A common misnomer in programming is the use of the words argument and parameter. When writing a function or method's signature (declaring the method), the values being passed to a method are called `parameters`, not `arguments`. When calling a function or method, the values passed to the call are formally known as `arguments`.

Example of parameters:
```ruby
def method_with_parameters(param1, param2)
    param1 + param2
end
```
Example of arguments:
```ruby
method_with_parameters(1, 2) # 1 & 2 are arguments
```