### PR TITLE
Fix "bad" version of do-end example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -660,9 +660,7 @@ In either case:
     names.each { |name| puts name }
 
     # bad
-    names.each do |name|
-      puts name
-    end
+    names.each do |name| puts name end
 
     # good
     names.select { |name| name.start_with?("S") }.map { |name| name.upcase }


### PR DESCRIPTION
Based on what was said in the previous paragraph,
I believe this example was meant to show that we
don't want "do...end" on a single line.