### PR TITLE
Add indentation rule for multi-line boolean expression

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,24 @@ Airbnb also maintains a [JavaScript Style Guide][airbnb-javascript].
     end
     ```
 
+* Indent succeeding lines in multi-line boolean expressions.
+
+    ```ruby
+    # good
+    def is_eligible?(user)
+      Trebuchet.current.launch?(ProgramEligibilityHelper::PROGRAM_TREBUCHET_FLAG) &&
+        is_in_program?(user) &&
+        program_not_expired
+    end
+
+    # bad
+    def is_eligible?(user)
+      Trebuchet.current.launch?(ProgramEligibilityHelper::PROGRAM_TREBUCHET_FLAG) &&
+      is_in_program?(user) &&
+      program_not_expired
+    end
+    ```
+
 ### Inline
 
 * Never leave trailing whitespace.


### PR DESCRIPTION
I believe this is easier to read and is worth pointing out for individuals who are coming from a non-Ruby background where this situation does not arise (because there may not be standalone boolean expressions)

to: @clizzin 