### PR TITLE
Use bang, not not.

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,7 +517,7 @@ In either case:
     end
     ```
 
-* The `and` and `or` keywords are banned. It's just not worth it. Always use `&&` and `||` instead.
+* The `and`, `or`, and `not` keywords are banned. It's just not worth it. Always use `&&`, `||`, and `!` instead.
 
 * Modifier `if/unless` usage is okay when the body is simple, the
   condition is simple, and the whole thing fits on one line. Otherwise,


### PR DESCRIPTION
cc: @romanfuchs @nelgau 

`not` falls in the same category as `and` and `or` and perhaps we should avoid its use.

If a good citizen is changing `and` and `or` to `&&` and `||` in existing code, but does not also change `not` to `!` in the same expression, they run a stronger risk of breaking existing logic.
