### PR TITLE
[private definition] Add a new line between private/protected and method definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -894,7 +894,7 @@ in inheritance.
     ```
 
 * Indent the `public`, `protected`, and `private` methods as much the
-  method definitions they apply to. Leave one blank line above them.
+  method definitions they apply to. Leave one blank line above and below them.
 
     ```Ruby
     class SomeClass

--- a/README.md
+++ b/README.md
@@ -903,6 +903,7 @@ in inheritance.
       end
 
       private
+
       def private_method
         # ...
       end


### PR DESCRIPTION
We should add a new line between `private` and `protected` and the method definition underneath it.

Example:
```
class Person

  def age
  end

  protected

  def dob
  end
end
```