### PR TITLE
[datetime] Prefer Date.current and Time.current

### DIFF
--- a/README.md
+++ b/README.md
@@ -1133,6 +1133,10 @@ in inheritance.
     end
     ```
 
+* Prefer `Time.current` over `Time.now`
+
+* Prefer `Date.current` over `Date.today`
+
 ## Be Consistent
 
 > If you're editing code, take a few minutes to look at the code around you and


### PR DESCRIPTION
If we use `Time.now`, it will use the server's timezone.

If we use `Time.current`, it will look in the default timezone stated in the `config` file. If it is present, it will use that timezone. If it is not present, it will default to use the server's timezone.

With `Time.current` you get `Time.now` and some.