### PR TITLE
[tommy] Change Ruby to ruby in syntax highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Airbnb also maintains a [JavaScript Style Guide][airbnb-javascript].
 
 * Indent `when` as deep as `case`.
 
-    ```Ruby
+    ```ruby
     case
     when song.name == 'Misty'
       puts 'Not again!'
@@ -125,7 +125,7 @@ Airbnb also maintains a [JavaScript Style Guide][airbnb-javascript].
 * Use spaces around operators; after commas, colons, and semicolons; and around
   `{` and before `}`.
 
-    ```Ruby
+    ```ruby
     sum = 1 + 2
     a, b = 1, 2
     1 > 2 ? true : false; puts 'Hi'
@@ -134,7 +134,7 @@ Airbnb also maintains a [JavaScript Style Guide][airbnb-javascript].
 
 * No spaces after `(`, `[` or before `]`, `)`.
 
-    ```Ruby
+    ```ruby
     some(arg).other
     [1, 2, 3].length
     ```
@@ -432,7 +432,7 @@ Never leave commented-out code in our codebase.
 * Use `def` with parentheses when there are parameters. Omit the
   parentheses when the method doesn't accept any parameters.
 
-     ```Ruby
+     ```ruby
      def some_method
        # body omitted
      end
@@ -444,7 +444,7 @@ Never leave commented-out code in our codebase.
 
 * Do not use default arguments. Use an options hash instead.
 
-    ```Ruby
+    ```ruby
     # bad
     def obliterate(things, gently = true, except = [], at = Time.now)
       ...
@@ -489,7 +489,7 @@ Never leave commented-out code in our codebase.
 
 * Never put a space between a method name and the opening parenthesis.
 
-    ```Ruby
+    ```ruby
     # bad
     f (3 + 2) + 1
 
@@ -536,7 +536,7 @@ In either case:
 
 * Never use `then` for multi-line `if/unless`.
 
-    ```Ruby
+    ```ruby
     # bad
     if some_condition then
       ...
@@ -554,7 +554,7 @@ In either case:
   condition is simple, and the whole thing fits on one line. Otherwise,
   avoid modifier `if/unless`.
 
-    ```Ruby
+    ```ruby
     # bad - this doesn't fit on one line
     add_trebuchet_experiments_on_page(request_opts[:trebuchet_experiments_on_page]) if request_opts[:trebuchet_experiments_on_page] && !request_opts[:trebuchet_experiments_on_page].empty?
 
@@ -574,7 +574,7 @@ In either case:
 
 * Never use `unless` with `else`. Rewrite these with the positive case first.
 
-    ```Ruby
+    ```ruby
     # bad
     unless success?
       puts 'failure'
@@ -592,7 +592,7 @@ In either case:
 
 * Avoid `unless` with multiple conditions.
 
-    ```Ruby
+    ```ruby
       # bad
       unless foo? && bar?
         ...
@@ -606,7 +606,7 @@ In either case:
 
 * Don't use parentheses around the condition of an `if/unless/while`.
 
-    ```Ruby
+    ```ruby
     # bad
     if (x > 10)
       ...
@@ -625,7 +625,7 @@ In either case:
   extremely trivial. However, do use the ternary operator(`?:`) over
   `if/then/else/end` constructs for single line conditionals.
 
-    ```Ruby
+    ```ruby
     # bad
     result = if some_condition then something else something_else end
 
@@ -637,7 +637,7 @@ In either case:
   also means that ternary operators must not be nested. Prefer
   `if/else` constructs in these cases.
 
-    ```Ruby
+    ```ruby
     # bad
     some_condition ? (nested_condition ? nested_something : nested_something_else) : something_else
 
@@ -652,7 +652,7 @@ In either case:
 * Avoid multiple conditions in ternaries. Ternaries are best used with single conditions.
 
 * Avoid multi-line `?:` (the ternary operator), use `if/then/else/end` instead.
-    ```Ruby
+    ```ruby
     # bad
     some_really_long_condition_that_might_make_you_want_to_split_lines ?
       something : something_else
@@ -673,7 +673,7 @@ In either case:
   doesn't introduce a new scope (unlike `each`) and variables defined
   in its block will be visible outside it.
 
-    ```Ruby
+    ```ruby
     arr = [1, 2, 3]
 
     # bad
@@ -692,7 +692,7 @@ In either case:
   definitions" (e.g. in Rakefiles and certain DSLs).  Avoid `do...end`
   when chaining.
 
-    ```Ruby
+    ```ruby
     names = ["Bozhidar", "Steve", "Sarah"]
 
     # good
@@ -716,7 +716,7 @@ In either case:
 
 * Avoid `return` where not required.
 
-    ```Ruby
+    ```ruby
     # bad
     def some_method(some_arr)
       return some_arr.size
@@ -730,7 +730,7 @@ In either case:
 
 * Don't use the return value of `=` in conditionals
 
-    ```Ruby
+    ```ruby
     # bad - shows intended use of assignment
     if (v = array.grep(/foo/))
       ...
@@ -751,7 +751,7 @@ In either case:
 
 * Use `||=` freely to initialize variables.
 
-    ```Ruby
+    ```ruby
     # set name to Bozhidar, only if it's nil or false
     name ||= 'Bozhidar'
     ```
@@ -759,7 +759,7 @@ In either case:
 * Don't use `||=` to initialize boolean variables. (Consider what
   would happen if the current value happened to be `false`.)
 
-    ```Ruby
+    ```ruby
     # bad - would set enabled to true even if it was false
     enabled ||= true
 
@@ -774,7 +774,7 @@ In either case:
 
 * Use `_` for unused block arguments.
 
-    ```Ruby
+    ```ruby
     # bad
     result = hash.map { |k, v| v + 1 }
 
@@ -837,7 +837,7 @@ In either case:
   ([More on this][ruby-naming-bang].)
 
 * Name throwaway variables `_`.
-    ```Ruby
+    ```ruby
     payment, _ = Payment.complete_paypal_payment!(params[:token],
                                                   native_currency,
                                                   created_at)
@@ -848,7 +848,7 @@ In either case:
 * Avoid the usage of class (`@@`) variables due to their "nasty" behavior
 in inheritance.
 
-    ```Ruby
+    ```ruby
     class Parent
       @@class_var = 'parent'
 
@@ -871,7 +871,7 @@ in inheritance.
 * Use `def self.method` to define singleton methods. This makes the methods
   more resistant to refactoring changes.
 
-    ```Ruby
+    ```ruby
     class TestClass
       # bad
       def TestClass.some_method
@@ -886,7 +886,7 @@ in inheritance.
 * Avoid `class << self` except when necessary, e.g. single accessors and aliased
   attributes.
 
-    ```Ruby
+    ```ruby
     class TestClass
       # bad
       class << self
@@ -918,7 +918,7 @@ in inheritance.
 * Indent the `public`, `protected`, and `private` methods as much the
   method definitions they apply to. Leave one blank line above and below them.
 
-    ```Ruby
+    ```ruby
     class SomeClass
       def public_method
         # ...
@@ -936,7 +936,7 @@ in inheritance.
 
 * Don't use exceptions for flow of control.
 
-    ```Ruby
+    ```ruby
     # bad
     begin
       n / d
@@ -954,7 +954,7 @@ in inheritance.
 
 * Avoid rescuing the `Exception` class.
 
-    ```Ruby
+    ```ruby
     # bad
     begin
       # an exception occurs here
@@ -996,7 +996,7 @@ in inheritance.
 
 * Use symbols instead of strings as hash keys.
 
-    ```Ruby
+    ```ruby
     # bad
     hash = { 'one' => 1, 'two' => 2, 'three' => 3 }
 
@@ -1037,7 +1037,7 @@ in inheritance.
 
 * Prefer string interpolation instead of string concatenation:
 
-    ```Ruby
+    ```ruby
     # bad
     email_with_name = user.name + ' <' + user.email + '>'
 
@@ -1066,7 +1066,7 @@ in inheritance.
   Instead, use `String#<<`. Concatenation mutates the string instance in-place
   and is always faster than `String#+`, which creates a bunch of new string objects.
 
-    ```Ruby
+    ```ruby
     # good and also fast
     html = ''
     html << '<h1>Page title</h1>'
@@ -1081,7 +1081,7 @@ in inheritance.
 * Avoid using `$1-9` as it can be hard to track what they contain. Named groups
   can be used instead.
 
-    ```Ruby
+    ```ruby
     # bad
     /(regexp)/ =~ string
     ...
@@ -1096,7 +1096,7 @@ in inheritance.
 * Be careful with `^` and `$` as they match start/end of line, not string
   endings.  If you want to match the whole string use: `\A` and `\z`.
 
-    ```Ruby
+    ```ruby
     string = "some injection\nusername"
     string[/^username$/]   # matches
     string[/\Ausername\z/] # don't match
@@ -1105,7 +1105,7 @@ in inheritance.
 * Use `x` modifier for complex regexps. This makes them more readable and you
   can add some useful comments. Just be careful as spaces are ignored.
 
-    ```Ruby
+    ```ruby
     regexp = %r{
       start         # some text
       \s            # white space char
@@ -1119,14 +1119,14 @@ in inheritance.
 
 * Use `%w` freely.
 
-    ```Ruby
+    ```ruby
     STATES = %w(draft open closed)
     ```
 
 * Use `%()` for single-line strings which require both interpolation
   and embedded double-quotes. For multi-line strings, prefer heredocs.
 
-    ```Ruby
+    ```ruby
     # bad - no interpolation needed
     %(<div class="text">Some text</div>)
     # should be '<div class="text">Some text</div>'
@@ -1145,7 +1145,7 @@ in inheritance.
 
 * Use `%r` only for regular expressions matching *more than* one '/' character.
 
-    ```Ruby
+    ```ruby
     # bad
     %r(\s+)
 


### PR DESCRIPTION
to:
cc:
priority: low
size: small

Contents:
- When highlighting blocks of code, instead of using `Ruby`, we should use `ruby` since that is typically what Github prefers (less keystrokes for you as well :-D)