### PR TITLE
Use hashrocket instead of JSON syntax for hashes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -994,14 +994,14 @@ in inheritance.
 
 * Prefer `size` over either `length` or `count` for performance reasons.
 
-* Use hashrocket syntax instead of JSON syntax for hashes.
+* Use hashrocket syntax instead of JSON syntax for hashes. Hashrocket works no matter what type the key is, and symbol keys + symbol values look wonky in the JSON syntax.
 
-    ```Ruby
+    ```ruby
     # bad
-    hash = { one: 1, two: 2, three: 3 }
+    hash = { one: 1, two: 2, action: :update }
 
     # good
-    hash = { :one => 1, :two => 2, :three => 3 }
+    hash = { :one => 1, :two => 2, :action => :update }
     ```
 
 * Use symbols instead of strings as hash keys.

--- a/README.md
+++ b/README.md
@@ -994,6 +994,16 @@ in inheritance.
 
 * Prefer `size` over either `length` or `count` for performance reasons.
 
+* Use hashrocket syntax instead of JSON syntax for hashes.
+
+    ```Ruby
+    # bad
+    hash = { one: 1, two: 2, three: 3 }
+
+    # good
+    hash = { :one => 1, :two => 2, :three => 3 }
+    ```
+
 * Use symbols instead of strings as hash keys.
 
     ```Ruby


### PR DESCRIPTION
Rationale: see discussion for PR #64.

cc @akuhn @ljharb @robotpistol @venantius @tommydangerous 