### PR TITLE
[tommy] Moved indentation examples into rationales

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,87 +41,21 @@ Airbnb also maintains a [JavaScript Style Guide][airbnb-javascript].
 
 ### Indentation
 
-* <a name="default-indentation"></a>Use soft-tabs with a two
-    space-indent.<sup>[[link](#default-indentation)]</sup>
-
-* <a name="indent-when-as-case"></a>Indent `when` as deep as `case`.
-    <sup>[[link](#indent-when-as-case)]</sup>
-
-    ```ruby
-    case
-    when song.name == 'Misty'
-      puts 'Not again!'
-    when song.duration > 120
-      puts 'Too long!'
-    when Time.now.hour > 21
-      puts "It's too late"
-    else
-      song.play
-    end
-
-    kind = case year
-           when 1850..1889 then 'Blues'
-           when 1890..1909 then 'Ragtime'
-           when 1910..1929 then 'New Orleans Jazz'
-           when 1930..1939 then 'Swing'
-           when 1940..1950 then 'Bebop'
-           else 'Jazz'
-           end
-    ```
-
-* <a name="align-function-params"></a>Align function parameters either all on
-    the same line or one per line.<sup>[[link](#align-function-params)]</sup>
-
-    ```ruby
-    # good
-    def self.create_translation(phrase_id,
-                                phrase_key,
-                                target_locale,
-                                value,
-                                user_id,
-                                do_xss_check,
-                                allow_verification)
-      ...
-    end
-
-    # good
-    def self.create_translation(
-      phrase_id,
-      phrase_key,
-      target_locale,
-      value,
-      user_id,
-      do_xss_check,
-      allow_verification
-    )
-      ...
-    end
-
-    # bad
-    def self.create_translation(phrase_id, phrase_key, target_locale,
-                                value, user_id, do_xss_check, allow_verification)
-      ...
-    end
-    ```
-
-* <a name="indent-multi-line-bool"></a>Indent succeeding lines in multi-line
-    boolean expressions.<sup>[[link](#indent-multi-line-bool)]</sup>
-
-    ```ruby
-    # good
-    def is_eligible?(user)
-      Trebuchet.current.launch?(ProgramEligibilityHelper::PROGRAM_TREBUCHET_FLAG) &&
-        is_in_program?(user) &&
-        program_not_expired
-    end
-
-    # bad
-    def is_eligible?(user)
-      Trebuchet.current.launch?(ProgramEligibilityHelper::PROGRAM_TREBUCHET_FLAG) &&
-      is_in_program?(user) &&
-      program_not_expired
-    end
-    ```
+* <a name="default-indentation"></a>
+  Use soft-tabs with a twospace-indent.
+  <sup>[[link](#default-indentation)]</sup>
+* <a name="indent-when-as-case"></a>
+  Indent `when` as deep as `case`.
+  [Example](./rationales.md#indent-when-as-case)
+  <sup>[[link](#indent-when-as-case)]</sup>
+* <a name="align-function-params"></a>
+  Align function parameters either all on the same line or one per line.
+  [Example](./rationales.md#align-function-params)
+  <sup>[[link](#align-function-params)]</sup>
+* <a name="indent-multi-line-bool"></a>
+  Indent succeeding lines in multi-line boolean expressions.
+  [Example](./rationales.md#indent-multi-line-bool)
+  <sup>[[link](#indent-multi-line-bool)]</sup>
 
 ### Inline
 
@@ -606,7 +540,7 @@ In either case:
     end
     ```
 
-* <a name="single-condition-ternary"></a>Avoid multiple conditions in ternaries. 
+* <a name="single-condition-ternary"></a>Avoid multiple conditions in ternaries.
     Ternaries are best used with single conditions.
     <sup>[[link](#single-condition-ternary)]</sup>
 
@@ -629,7 +563,7 @@ In either case:
 
 ## Syntax
 
-* <a name="no-for"></a>Never use `for`, unless you know exactly why. Most of the 
+* <a name="no-for"></a>Never use `for`, unless you know exactly why. Most of the
     time iterators should be used instead. `for` is implemented in terms of
     `each` (so you're adding a level of indirection), but with a twist - `for`
     doesn't introduce a new scope (unlike `each`) and variables defined in its
@@ -763,7 +697,7 @@ In either case:
     bluths.select(&:blue_self?)
     ```
 
-* <a name="redundant-self"></a>Prefer `some_method` over `self.some_method` when 
+* <a name="redundant-self"></a>Prefer `some_method` over `self.some_method` when
     calling a method on the current instance.<sup>[[link](#redundant-self)]</sup>
 
     ```ruby

--- a/rationales.md
+++ b/rationales.md
@@ -4,7 +4,91 @@ This document contains what are at times lengthy rationales and justifications
 for the decisions made in the main [Style guide](./README.md).
 
 ## Table of Contents
-  1.  [Line Length](#line-length)
+  1. [Whitespace](#whitespace)
+    1. [Indentation](#indentation)
+  1. [Line Length](#line-length)
+
+## Whitespace
+
+### Indentation
+
+<a name="indent-when-as-case"></a>
+Indent `when` as deep as `case`.
+```ruby
+# bad
+kind = case year
+       when 1850..1889 then 'Blues'
+       when 1890..1909 then 'Ragtime'
+       when 1910..1929 then 'New Orleans Jazz'
+       when 1930..1939 then 'Swing'
+       when 1940..1950 then 'Bebop'
+       else 'Jazz'
+       end
+
+# good
+case
+when song.name == 'Misty'
+  puts 'Not again!'
+when song.duration > 120
+  puts 'Too long!'
+when Time.now.hour > 21
+  puts "It's too late"
+else
+  song.play
+end
+```
+
+<a name="align-function-params"></a>
+Align function parameters either all on the same line or one per line.
+```ruby
+# bad
+def self.create_translation(phrase_id, phrase_key, target_locale,
+                            value, user_id, do_xss_check, allow_verification)
+  ...
+end
+
+# good
+def self.create_translation(phrase_id,
+                            phrase_key,
+                            target_locale,
+                            value,
+                            user_id,
+                            do_xss_check,
+                            allow_verification)
+  ...
+end
+
+# good
+def self.create_translation(
+  phrase_id,
+  phrase_key,
+  target_locale,
+  value,
+  user_id,
+  do_xss_check,
+  allow_verification
+)
+  ...
+end
+```
+
+<a name="indent-multi-line-bool"></a>
+Indent succeeding lines in multi-line boolean expressions.
+```ruby
+# bad
+def is_eligible?(user)
+  Trebuchet.current.launch?(ProgramEligibilityHelper::PROGRAM_TREBUCHET_FLAG) &&
+  is_in_program?(user) &&
+  program_not_expired
+end
+
+# good
+def is_eligible?(user)
+  Trebuchet.current.launch?(ProgramEligibilityHelper::PROGRAM_TREBUCHET_FLAG) &&
+    is_in_program?(user) &&
+    program_not_expired
+end
+```
 
 ### Line Length
 


### PR DESCRIPTION
to: (not sure who to tag on this)
cc:
priority: low
size: small

Contents:
- Extract the examples out of the `README` and into the `rationales`

Screenshots:
- `README`
<img width="694" alt="screenshot 2016-02-18 17 57 40" src="https://cloud.githubusercontent.com/assets/1066980/13164342/5dd0d908-d669-11e5-8fc3-3e819070ce98.png">

- `rationales`
<img width="955" alt="screenshot 2016-02-18 17 57 52" src="https://cloud.githubusercontent.com/assets/1066980/13164347/643eb634-d669-11e5-942d-c61c5d72ec6d.png">
