### PR TITLE
Revert "Merge pull request #71 from airbnb/brian-morearty-hashrocket"

### DIFF
--- a/README.md
+++ b/README.md
@@ -978,16 +978,6 @@ In either case:
 * <a name="size-over-count"></a>Prefer `size` over either `length` or `count`
     for performance reasons.<sup>[[link](#size-over-count)]</sup>
 
-* Use hashrocket syntax instead of JSON syntax for hashes. Hashrocket works no matter what type the key is, and symbol keys + symbol values look wonky in the JSON syntax.
-
-    ```ruby
-    # bad
-    hash = { one: 1, two: 2, action: :update }
-
-    # good
-    hash = { :one => 1, :two => 2, :action => :update }
-    ```
-
 * Use symbols instead of strings as hash keys.
 
     ```ruby


### PR DESCRIPTION
I regret ever suggesting this guideline (or any guideline about which hash syntax we prefer) a week ago. It was foolish consistency--consistency for its own sake. It doesn't help anyone. I'd like to revert it.