### PR TITLE
[fix] Fixing bad spacing on example

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ Airbnb also maintains a [JavaScript Style Guide][airbnb-javascript].
 
     ```ruby
     if @reservation_alteration.checkin == @reservation.start_date &&
-       @reservation_alteration.checkout == (@reservation.start_date + @reservation.nights)
+        @reservation_alteration.checkout == (@reservation.start_date + @reservation.nights)
 
       redirect_to_alteration @reservation_alteration
     end


### PR DESCRIPTION
The newline example should have two spaces for the multi-line conditional, not
one.

cc @plberg