### PR TITLE
[readme] Remove set-unique rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -1216,11 +1216,6 @@ In either case:
 
 ## Collections
 
-* <a name="set-unique"></a>Use `Set` instead of `Array` when dealing with unique
-    elements. `Set` implements a collection of unordered values with no
-    duplicates. This is a hybrid of `Array`'s intuitive inter-operation
-    facilities and `Hash`'s fast lookup.<sup>[[link](#set-unique)]</sup>
-
 * <a name="map-over-collect"></a>Prefer `map` over
     `collect`.<sup>[[link](#map-over-collect)]</sup>
 


### PR DESCRIPTION
Remove `set-unique` rule because it's not a matter of style and more of Computer science concept of using appropriate data structure for the relevant operations.

@venantius 