### PR TITLE
[tommy] Add space after TODO in comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,7 +487,7 @@ Thus when you create a TODO, it is almost always your name that is given.
   # TODO(drumm3rz4lyfe): Use proper namespacing for this constant.
 
   # good
-  # TODO(Ringo Starr): Use proper namespacing for this constant.
+  # TODO (Ringo Starr): Use proper namespacing for this constant.
 ```
 
 ### Commented-out code


### PR DESCRIPTION
to:
cc:
priority: low
size: small

Contents:
- Add a space between `TODO` and `(`
- It doesn't seem right to have `(first_name last_name)` come right after `TODO` without a space