### PR TITLE
Remove link to github's styleguide bec. 404

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is Airbnb's Ruby Style Guide.
 
-It was inspired by [Github's guide][github-ruby] and [Bozhidar Batsov's guide][bbatsov-ruby].
+It was inspired by [Github's guide](https://web.archive.org/web/20160410033955/https://github.com/styleguide/ruby) and [Bozhidar Batsov's guide][bbatsov-ruby].
 
 Airbnb also maintains a [JavaScript Style Guide][airbnb-javascript].
 


### PR DESCRIPTION
The link to github's styleguide leads to a 404.  Was unable to find a new url.