### PR TITLE
[ruby] Add example against { } in multi-line block

### DIFF
--- a/README.md
+++ b/README.md
@@ -834,6 +834,18 @@ In either case:
 
     # good
     names.select { |name| name.start_with?("S") }.map { |name| name.upcase }
+    
+    # bad
+    names.each { |name|
+      puts name
+      print "\n"
+    }
+    
+    # good
+    names.each do |name|
+      puts name
+      print "\n"
+    end
 
     # bad
     names.select do |name|


### PR DESCRIPTION
The syntax rule that advises against using braces for multi-line blocks is stated, but there isn't an illustrated example listed, so it's easily overlooked by some who are skimming the guide for best practices. Added an example so that it's more obvious.