### PR TITLE
Add example against {} in multiline block

### DIFF
--- a/README.md
+++ b/README.md
@@ -833,6 +833,18 @@ In either case:
     names.each do |name| puts name end
 
     # good
+    names.each do |name|
+      puts name
+      puts 'yay!'
+    end
+
+    # bad
+    names.each { |name|
+      puts name
+      puts 'yay!'
+    }
+
+    # good
     names.select { |name| name.start_with?("S") }.map { |name| name.upcase }
 
     # bad


### PR DESCRIPTION
couldn't figure out how to modify this patch https://github.com/airbnb/ruby/pull/98 for some reason :/

this pr keeps the correct examples grouped together, while adding a new example (see #98 for more details)

@kmsun07