### PR TITLE
Updated links to google style guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1593,9 +1593,9 @@ In either case:
 [airbnb-javascript]: https://github.com/airbnb/javascript
 [bbatsov-ruby]: https://github.com/bbatsov/ruby-style-guide
 [github-ruby]: https://github.com/styleguide/ruby
-[google-c++]: http://google-styleguide.googlecode.com/svn/trunk/cppguide.xml
-[google-c++-comments]: http://google-styleguide.googlecode.com/svn/trunk/cppguide.xml#Comments
-[google-python-comments]: http://google-styleguide.googlecode.com/svn/trunk/pyguide.html#Comments
+[google-c++]: https://google.github.io/styleguide/cppguide.html
+[google-c++-comments]: https://google.github.io/styleguide/cppguide.html#Comments
+[google-python-comments]: https://google.github.io/styleguide/pyguide.html#Comments
 [ruby-naming-bang]: http://dablog.rubypal.com/2007/8/15/bang-methods-or-danger-will-rubyist
 
 ## Translation


### PR DESCRIPTION
Google has moved from google code to github. Updated links to reflect that move