### PR TITLE
Update options hash example style

### DIFF
--- a/README.md
+++ b/README.md
@@ -525,12 +525,11 @@ Thus when you create a TODO, it is almost always your name that is given.
 
     # good
     def obliterate(things, options = {})
-      default_options = {
+      options = {
         :gently => true, # obliterate with soft-delete
         :except => [], # skip obliterating these things
         :at => Time.now, # don't obliterate them until later
-      }
-      options.reverse_merge!(default_options)
+      }.merge(options)
 
       ...
     end


### PR DESCRIPTION
using `reverse_merge!` performs a mutation - since the hash can be passed by reference, it may mutate values on the object even outside the function. Switch to an assignment syntax so that we get a new reference/object and thus do not cause a side effect to the caller

would also be open to 
```
options = options.reverse_merge({
  # the default options in-lined
})
```

@robotpistol 