### PR TITLE
Add rule discouraging `unless` with comparators

### DIFF
--- a/README.md
+++ b/README.md
@@ -727,8 +727,6 @@ In either case:
         ...
       end
     ```
-    
-    
 
 * <a name="unless-with-comparator"></a>Avoid `unless` with comparators if you can use `if` with an opposing comparator.<sup>[[link](#unless-with-comparator)]</sup>
 

--- a/README.md
+++ b/README.md
@@ -727,6 +727,32 @@ In either case:
         ...
       end
     ```
+    
+    
+
+* <a name="unless-with-comparator"></a>Avoid `unless` with comparators if you can use `if` with an opposing comparator.<sup>[[link](#unless-with-comparator)]</sup>
+
+    ```ruby     
+      # bad
+      unless x == 10
+        ...
+      end
+      
+      # good
+      if x != 10
+        ...
+      end
+      
+      # bad
+      unless x < 10
+        ...
+      end
+      
+      # good
+      if x >= 10
+        ...
+      end
+    ```
 
 * <a name="parens-around-conditions"></a>Don't use parentheses around the
     condition of an `if/unless/while`.


### PR DESCRIPTION
Prefer `if` with the reverse comparator if available

@robotpistol @aagrawal2001 @BMorearty 