### PR TITLE
Update unless with comparator rule with unreversible example

### DIFF
--- a/README.md
+++ b/README.md
@@ -728,7 +728,7 @@ In either case:
       end
     ```
 
-* <a name="unless-with-comparator"></a>Avoid `unless` with comparators if you can use `if` with an opposing comparator.<sup>[[link](#unless-with-comparator)]</sup>
+* <a name="unless-with-comparison-operator"></a>Avoid `unless` with comparison operators if you can use `if` with an opposing comparison operator.<sup>[[link](#unless-with-comparison-operator)]</sup>
 
     ```ruby     
       # bad
@@ -748,6 +748,11 @@ In either case:
       
       # good
       if x >= 10
+        ...
+      end
+      
+      # ok
+      unless x === 10
         ...
       end
     ```


### PR DESCRIPTION
also rename comparator to the more official name, comparison operator

i still maintain there is no rationale here and thus no need to force one. previous discussion is once again at https://github.com/airbnb/ruby/issues/74

please do not approve this PR unless you are OK with it being merged as is (that is, you would consider it an improvement over the currently live version), and please request changes if you have what you consider to be showstopper suggestions

@ljharb @aagrawal2001 