### PR TITLE
Change casing of COLOR to Color.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1127,7 +1127,7 @@ In either case:
     attempting to modify them will raise an exception. 
 
     ```ruby
-    class COLOR
+    class Color
       # Each color
       RED = 0
       BLUE = 1


### PR DESCRIPTION
Fixes a typo from my previous commit where ```class COLOR``` should have been ```class Color```.
@BMorearty @kmsun07 