### PR TITLE
Update example for throwaway variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1194,9 +1194,12 @@ In either case:
     <sup>[[link](#throwaway-variables)]</sup>
 
     ```ruby
-    payment, _ = Payment.complete_paypal_payment!(params[:token],
-                                                  native_currency,
-                                                  created_at)
+    {
+      a: 1,
+      b: 2,
+    }.each do |key, _|
+      puts key
+    end
     ```
 
 ## Classes

--- a/README.md
+++ b/README.md
@@ -1194,12 +1194,8 @@ In either case:
     <sup>[[link](#throwaway-variables)]</sup>
 
     ```ruby
-    {
-      a: 1,
-      b: 2,
-    }.each do |key, _|
-      puts key
-    end
+    version = '3.2.1'
+    major_version, minor_version, _ = version.split('.')
     ```
 
 ## Classes


### PR DESCRIPTION
The example cites a function that is not only opaque to most readers, but doesn't even exist in airbnb's codebase anymore. Thus, the interpretation may be lost, as nobody knows what the expected return value(s) of the function is. Replace it with standard ruby function(s)

@robotpistol 