### PR TITLE
Recommend named arguments for default arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -514,12 +514,17 @@ Thus when you create a TODO, it is almost always your name that is given.
      end
      ```
 
-* <a name="no-default-args"></a>Do not use default arguments. Use an options
+* <a name="no-default-args"></a>Do not use default positional arguments. Use named arguments or an options
     hash instead.<sup>[[link](#no-default-args)]</sup>
 
     ```ruby
     # bad
     def obliterate(things, gently = true, except = [], at = Time.now)
+      ...
+    end
+
+    # good
+    def obliterate(things, gently: true, except: [], at: Time.now)
       ...
     end
 

--- a/README.md
+++ b/README.md
@@ -514,7 +514,8 @@ Thus when you create a TODO, it is almost always your name that is given.
      end
      ```
 
-* <a name="no-default-args"></a>Do not use default positional arguments. Use named arguments or an options
+* <a name="no-default-args"></a>Do not use default positional arguments. 
+    Use keyword arguments (if available - in Ruby 2.0 or later) or an options
     hash instead.<sup>[[link](#no-default-args)]</sup>
 
     ```ruby


### PR DESCRIPTION
as an alternative to options hash.

clarify the rule to call out positional arguments only - default named arguments are encouraged.

@robotpistol 