### PR TITLE
Upgrade to rubocop 0.54.0

### DIFF
--- a/rubocop-airbnb/.rubocop.yml
+++ b/rubocop-airbnb/.rubocop.yml
@@ -4,9 +4,6 @@ inherit_from:
 
 AllCops:
   CacheRootDirectory: tmp/rubocop
-  Exclude:
-    - 'vendor/**/*'
-    - 'node_modules/**/*'
 
 Rails:
   Enabled: false

--- a/rubocop-airbnb/config/rubocop-layout.yml
+++ b/rubocop-airbnb/config/rubocop-layout.yml
@@ -40,6 +40,11 @@ Layout/AlignParameters:
   - with_fixed_indentation
 
 # Supports --auto-correct
+Layout/BlockAlignment:
+  Description: Align block ends correctly.
+  Enabled: true
+
+# Supports --auto-correct
 Layout/BlockEndNewline:
   Description: Put end statement of multiline block on its own line.
   Enabled: true
@@ -78,6 +83,18 @@ Layout/CommentIndentation:
   Description: Indentation of comments.
   Enabled: true
 
+Layout/ConditionPosition:
+  Description: Checks for condition placed in a confusing position relative to the keyword.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#same-line-condition
+  Enabled: true
+
+# Supports --auto-correct
+Layout/DefEndAlignment:
+  Description: Align ends corresponding to defs correctly.
+  Enabled: true
+  EnforcedStyleAlignWith: start_of_line
+  AutoCorrect: false
+
 # Use trailing commas, because there are safer in ruby.
 Layout/DotPosition:
   Enabled: true
@@ -86,6 +103,10 @@ Layout/DotPosition:
 # Supports --auto-correct
 Layout/ElseAlignment:
   Description: Align elses and elsifs correctly.
+  Enabled: true
+
+Layout/EmptyComment:
+  Description: 'Checks empty comment.'
   Enabled: true
 
 Layout/EmptyLineAfterMagicComment:
@@ -130,7 +151,9 @@ Layout/EmptyLinesAroundClassBody:
   Enabled: true
   EnforcedStyle: no_empty_lines
   SupportedStyles:
+  - beginning_only
   - empty_lines
+  - end_only
   - no_empty_lines
 
 Layout/EmptyLinesAroundExceptionHandlingKeywords:
@@ -149,6 +172,20 @@ Layout/EmptyLinesAroundModuleBody:
   SupportedStyles:
   - empty_lines
   - no_empty_lines
+
+# Supports --auto-correct
+Layout/EndAlignment:
+  Description: Align ends correctly.
+  # The value `keyword` means that `end` should be aligned with the matching
+  # keyword (if, while, etc.).
+  # The value `variable` means that in assignments, `end` should be aligned
+  # with the start of the variable on the left hand side of `=`. In all other
+  # situations, `end` should still be aligned with the keyword.
+  # The value `start_of_line` means that `end` should be aligned with the start
+  # of the line which the matching keyword appears on.
+  Enabled: true
+  EnforcedStyleAlignWith: keyword
+  AutoCorrect: false
 
 Layout/EndOfLine:
   Description: Use Unix-style line endings.
@@ -448,7 +485,7 @@ Layout/SpaceInsideArrayLiteralBrackets:
   Enabled: true
 
 Layout/SpaceInsideReferenceBrackets:
-  EnforcedStyle: no_space
+  EnforcedStyleForEmptyBrackets: no_space
   SupportedStyles:
     - space
     - no_space

--- a/rubocop-airbnb/config/rubocop-lint.yml
+++ b/rubocop-airbnb/config/rubocop-lint.yml
@@ -18,10 +18,9 @@ Lint/AssignmentInCondition:
   Enabled: true
   AllowSafeAssignment: false
 
-# Supports --auto-correct
-Lint/BlockAlignment:
-  Description: Align block ends correctly.
-  Enabled: true
+Lint/BigDecimalNew:
+  Description: '`BigDecimal.new()` is deprecated. Use `BigDecimal()` instead.'
+  Enabled: false
 
 Lint/BooleanSymbol:
   Enabled: false
@@ -30,21 +29,9 @@ Lint/CircularArgumentReference:
   Description: Don't refer to the keyword argument in the default value.
   Enabled: false
 
-Lint/ConditionPosition:
-  Description: Checks for condition placed in a confusing position relative to the keyword.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#same-line-condition
-  Enabled: true
-
 Lint/Debugger:
   Description: Check for debugger calls.
   Enabled: true
-
-# Supports --auto-correct
-Lint/DefEndAlignment:
-  Description: Align ends corresponding to defs correctly.
-  Enabled: true
-  EnforcedStyleAlignWith: start_of_line
-  AutoCorrect: false
 
 # Supports --auto-correct
 Lint/DeprecatedClassMethods:
@@ -80,20 +67,6 @@ Lint/EmptyInterpolation:
 
 Lint/EmptyWhen:
   Enabled: false
-
-# Supports --auto-correct
-Lint/EndAlignment:
-  Description: Align ends correctly.
-  # The value `keyword` means that `end` should be aligned with the matching
-  # keyword (if, while, etc.).
-  # The value `variable` means that in assignments, `end` should be aligned
-  # with the start of the variable on the left hand side of `=`. In all other
-  # situations, `end` should still be aligned with the keyword.
-  # The value `start_of_line` means that `end` should be aligned with the start
-  # of the line which the matching keyword appears on.
-  Enabled: true
-  EnforcedStyleAlignWith: keyword
-  AutoCorrect: false
 
 Lint/EndInMethod:
   Description: END blocks should not be placed inside method definitions.
@@ -178,6 +151,10 @@ Lint/NonLocalExitFromIterator:
   Description: Do not use return in iterator to cause non-local exit.
   Enabled: false
 
+Lint/OrderedMagicComments:
+  Description: 'Checks the proper ordering of magic comments and whether a magic comment is not placed before a shebang.'
+  Enabled: true
+
 Lint/ParenthesesAsGroupedExpression:
   Description: Checks for method calls with a space before the opening parenthesis.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#parens-no-spaces
@@ -254,10 +231,14 @@ Lint/UnderscorePrefixedVariableName:
 Lint/UnifiedInteger:
   Enabled: false
 
-Lint/UnneededDisable:
+Lint/UnneededCopDisableDirective:
   Description: >-
     Checks for rubocop:disable comments that can be removed.
     Note: this cop is not disabled when disabling all cops. It must be explicitly disabled.
+  Enabled: true
+
+Lint/UnneededCopEnableDirective:
+  Description: Checks for rubocop:enable comments that can be removed.
   Enabled: true
 
 Lint/UnneededRequireStatement:

--- a/rubocop-airbnb/config/rubocop-naming.yml
+++ b/rubocop-airbnb/config/rubocop-naming.yml
@@ -33,6 +33,11 @@ Naming/HeredocDelimiterCase:
 Naming/HeredocDelimiterNaming:
   Enabled: false
 
+Naming/MemoizedInstanceVariableName:
+  Description: >-
+    Memoized method name should match memo instance variable name.
+  Enabled: false
+
 Naming/MethodName:
   Description: Use the configured style when naming methods.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#snake-case-symbols-methods-vars
@@ -54,6 +59,18 @@ Naming/PredicateName:
   - is_
   - has_
   - have_
+
+Naming/UncommunicativeBlockParamName:
+  Description: >-
+              Checks for block parameter names that contain capital letters,
+              end in numbers, or do not meet a minimal length.
+  Enabled: false
+
+Naming/UncommunicativeMethodParamName:
+  Description: >-
+              Checks for method parameter names that contain capital letters,
+              end in numbers, or do not meet a minimal length.
+  Enabled: false
 
 Naming/VariableName:
   Description: Use the configured style when naming variables.

--- a/rubocop-airbnb/config/rubocop-performance.yml
+++ b/rubocop-airbnb/config/rubocop-performance.yml
@@ -54,14 +54,6 @@ Performance/FlatMap:
   EnabledForFlattenWithoutParams: false
 
 # Supports --auto-correct
-Performance/HashEachMethods:
-  Description: Use `Hash#each_key` and `Hash#each_value` instead of `Hash#keys.each`
-    and `Hash#values.each`.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#hash-each
-  Enabled: false
-  AutoCorrect: false
-
-# Supports --auto-correct
 Performance/LstripRstrip:
   Description: Use `strip` instead of `lstrip.rstrip`.
   Enabled: false

--- a/rubocop-airbnb/config/rubocop-rails.yml
+++ b/rubocop-airbnb/config/rubocop-rails.yml
@@ -2,6 +2,9 @@
 Rails/ActionFilter:
   Enabled: false
 
+Rails/ActiveRecordAliases:
+  Enabled: false
+
 Rails/ActiveSupportAliases:
   Enabled: false
 

--- a/rubocop-airbnb/config/rubocop-rails.yml
+++ b/rubocop-airbnb/config/rubocop-rails.yml
@@ -91,6 +91,9 @@ Rails/HasManyOrHasOneDependent:
 Rails/HttpPositionalArguments:
   Enabled: false
 
+Rails/HttpStatus:
+  Enabled: false
+
 Rails/InverseOf:
   Description: 'Checks for associations where the inverse cannot be determined automatically.'
   Enabled: false

--- a/rubocop-airbnb/config/rubocop-security.yml
+++ b/rubocop-airbnb/config/rubocop-security.yml
@@ -8,6 +8,10 @@ Security/JSONLoad:
 Security/MarshalLoad:
   Enabled: false
 
+Security/Open:
+  Description: 'The use of Kernel#open represents a serious security risk.'
+  Enabled: false
+
 Security/YAMLLoad:
   Enabled: false
 

--- a/rubocop-airbnb/config/rubocop-style.yml
+++ b/rubocop-airbnb/config/rubocop-style.yml
@@ -322,6 +322,10 @@ Style/EvenOdd:
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#predicate-methods
   Enabled: false
 
+Style/ExpandPathArguments:
+  Description: "Use `expand_path(__dir__)` instead of `expand_path('..', __FILE__)`."
+  Enabled: false
+
 Style/FlipFlop:
   Description: Checks for flip flops
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-flip-flops
@@ -433,6 +437,9 @@ Style/LineEndConcatenation:
   Description: Use \ instead of + or << to concatenate two string literals at line end.
   Enabled: true
 
+Style/EmptyLineAfterGuardClause:
+  Enabled: false
+
 Style/MethodCallWithArgsParentheses:
   Enabled: false
 
@@ -485,6 +492,7 @@ Style/MixinUsage:
     `include`, `extend` and `prepend` at the top level. Let's use it inside `class` or `module`.
   Enabled: true
 
+# Supports --auto-correct
 Style/ModuleFunction:
   Description: Checks for usage of `extend self` in modules.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#module-function
@@ -870,15 +878,28 @@ Style/SymbolProc:
 Style/TernaryParentheses:
   Enabled: false
 
+Style/TrailingBodyOnClass:
+  Description: 'Class body goes below class statement.'
+  Enabled: true
+
 Style/TrailingBodyOnMethodDefinition:
   Description: 'Method body goes below definition.'
+  Enabled: true
+
+Style/TrailingBodyOnModule:
+  Description: 'Module body goes below module statement.'
   Enabled: true
 
 Style/TrailingCommaInArguments:
   Enabled: false
 
-# Allow trailing commas (we like 'em!)
-Style/TrailingCommaInLiteral:
+# Enforce trailing commas (we like 'em!)
+Style/TrailingCommaInArrayLiteral:
+  Enabled: true
+  EnforcedStyleForMultiline: consistent_comma
+
+# Enforce trailing commas (we like 'em!)
+Style/TrailingCommaInHashLiteral:
   Enabled: true
   EnforcedStyleForMultiline: consistent_comma
 

--- a/rubocop-airbnb/config/rubocop-style.yml
+++ b/rubocop-airbnb/config/rubocop-style.yml
@@ -934,6 +934,9 @@ Style/UnneededPercentQ:
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#percent-q
   Enabled: false
 
+Style/UnpackFirst:
+  Enabled: false
+
 # Supports --auto-correct
 Style/VariableInterpolation:
   Description: Don't interpolate global, instance and class variables directly in strings.

--- a/rubocop-airbnb/rubocop-airbnb.gemspec
+++ b/rubocop-airbnb/rubocop-airbnb.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
     'Gemfile',
   ]
 
-  spec.add_dependency('rubocop', '0.53.0')
+  spec.add_dependency('rubocop', '0.54.0')
   spec.add_dependency('rubocop-rspec', '1.22.1')
   spec.add_development_dependency('rspec', '~> 3.5')
 end

--- a/rubocop-airbnb/rubocop-airbnb.gemspec
+++ b/rubocop-airbnb/rubocop-airbnb.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
     'Gemfile',
   ]
 
-  spec.add_dependency('rubocop', '0.52.1')
+  spec.add_dependency('rubocop', '0.53.0')
   spec.add_dependency('rubocop-rspec', '1.22.1')
   spec.add_development_dependency('rspec', '~> 3.5')
 end


### PR DESCRIPTION
Upgrade through 0.53.0 and 0.54.0

Add new cops
Move renamed cops.
No new cops were enabled in this PR.

@ljharb 
@airbnb/ruby-styleguide-maintainers 