### PR TITLE
Add cop to enforce single condition unless statements

### DIFF
--- a/rubocop-airbnb/config/rubocop-airbnb.yml
+++ b/rubocop-airbnb/config/rubocop-airbnb.yml
@@ -85,6 +85,10 @@ Airbnb/SimpleModifierConditional:
   Enabled: true
   StyleGuide: https://github.com/airbnb/ruby#only-simple-if-unless
 
+Airbnb/SimpleUnless:
+  Enabled: true
+  StyleGuide: https://github.com/airbnb/ruby#unless-with-multiple-conditions
+
 Airbnb/SpecConstantAssignment:
   Description: Constant assignment in specs polute global namespace and are a cause of spurious
     specs. They should be avoided. Also modifing existing constants is bad too, use stub_const

--- a/rubocop-airbnb/lib/rubocop/cop/airbnb/simple_unless.rb
+++ b/rubocop-airbnb/lib/rubocop/cop/airbnb/simple_unless.rb
@@ -1,0 +1,19 @@
+module RuboCop
+  module Cop
+    module Airbnb
+      # Cop to tackle prevent unless statements with multiple conditions
+      # https://github.com/airbnb/ruby#unless-with-multiple-conditions
+      class SimpleUnless < Cop
+        MSG = 'Unless usage is okay when there is only one conditional'.freeze
+
+        def_node_matcher :multiple_conditionals?, '(if ({and or :^} ...) ...)'
+
+        def on_if(node)
+          return unless node.unless?
+
+          add_offense(node) if multiple_conditionals?(node)
+        end
+      end
+    end
+  end
+end

--- a/rubocop-airbnb/spec/rubocop/cop/airbnb/simple_unless_spec.rb
+++ b/rubocop-airbnb/spec/rubocop/cop/airbnb/simple_unless_spec.rb
@@ -1,0 +1,36 @@
+describe RuboCop::Cop::Airbnb::SimpleUnless do
+  subject(:cop) { described_class.new }
+
+  it 'rejects unless with multiple conditionals' do
+    source = [
+      'unless boolean_condition || another_method',
+      '  return true',
+      'end',
+    ].join("\n")
+
+    inspect_source(source)
+    expect(cop.offenses.size).to eq(1)
+  end
+
+  it 'allows if with multiple conditionals' do
+    source = [
+      'if boolean_condition || another_method',
+      '  return true',
+      'end',
+    ].join("\n")
+
+    inspect_source(source)
+    expect(cop.offenses).to be_empty
+  end
+
+  it 'allows with modifier if operator conditional' do
+    source = [
+      'unless boolean_condition',
+      '  return true',
+      'end',
+    ].join("\n")
+
+    inspect_source(source)
+    expect(cop.offenses).to be_empty
+  end
+end


### PR DESCRIPTION
Add a cop to enforce the multiple unless rule in our style guide.

@BMorearty 
@airbnb/ruby-styleguide-maintainers 
@airbnb/ruby-styleguide-owners 