### PR TITLE
Bump version to 1.3.0

### DIFF
--- a/rubocop-airbnb/CHANGELOG.md
+++ b/rubocop-airbnb/CHANGELOG.md
@@ -1,2 +1,6 @@
+# 1.3.0
+* Upgrade to rubocop 0.54.0
+* Add SimpleUnless cop
+
 # 1.0.0
 * First public release of rubocop-airbnb

--- a/rubocop-airbnb/lib/rubocop/airbnb/version.rb
+++ b/rubocop-airbnb/lib/rubocop/airbnb/version.rb
@@ -3,6 +3,6 @@
 module RuboCop
   module Airbnb
     # Version information for the the Airbnb RuboCop plugin.
-    VERSION = '1.0.0'.freeze
+    VERSION = '1.3.0'.freeze
   end
 end


### PR DESCRIPTION
Bumping version a bit higher to avoid internal versioning confusion.

@ljharb 
@airbnb/ruby-styleguide-owners 
@airbnb/ruby-styleguide-maintainers 