### PR TITLE
Bump rubocop-rspec to latest, rubocop to 0.58

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ cache:
   bundler: true
 sudo: false
 rvm:
-  - 2.1
   - 2.2
   - 2.3
   - 2.4

--- a/rubocop-airbnb/CHANGELOG.md
+++ b/rubocop-airbnb/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 2.0.0
+* Upgrade to rubocop-rspec 1.30.0, use ~> to allow for PATCH version flexibility
+* Upgrade to rubocop 0.58.0, use ~> to allow for PATCH version flexibility
+* Enable RSpec/HooksBeforeExamples
+* Enable RSpec/MissingExampleGroupArgument
+* Enable RSpec/ReceiveNever
+* Remove FactoryBot/DynamicAttributeDefinedStatically
+* Remove FactoryBot/StaticAttributeDefinedDynamically
+
 # 1.5.0
 * Upgrade to rubocop-rspec 1.27.0
 * Enable RSpec/Be

--- a/rubocop-airbnb/config/rubocop-rspec.yml
+++ b/rubocop-airbnb/config/rubocop-rspec.yml
@@ -131,6 +131,10 @@ RSpec/HookArgument:
   - each
   - example
 
+RSpec/HooksBeforeExamples:
+  Description: Checks for before/around/after hooks that come after an example.
+  Enabled: true
+
 RSpec/ImplicitExpect:
   Description: Check that a consistent implicit expectation style is used.
   Enabled: false
@@ -138,6 +142,10 @@ RSpec/ImplicitExpect:
   SupportedStyles:
   - is_expected
   - should
+
+RSpec/ImplicitSubject:
+  Description: 'Checks for usage of implicit subject (`is_expected` / `should`).'
+  Enabled: false
 
 RSpec/InstanceSpy:
   Description: Checks for `instance_double` used with `have_received`.
@@ -195,6 +203,10 @@ RSpec/MessageSpies:
   - have_received
   - receive
 
+RSpec/MissingExampleGroupArgument:
+  Description: Checks that the first argument to an example group is not empty.
+  Enabled: true
+
 RSpec/MultipleDescribes:
   Description: 'Checks for multiple top level describes.'
   Enabled: true
@@ -216,6 +228,10 @@ RSpec/NestedGroups:
   Description: Checks for nested example groups.
   Enabled: false
   Max: 3
+
+RSpec/ReceiveNever:
+  Description: 'Prefer `not_to receive(…)` over `receive(…).never`.'
+  Enabled: true
 
 RSpec/NotToNot:
   Description: 'Enforces the usage of the same method on all negative message expectations.'
@@ -286,6 +302,10 @@ RSpec/SubjectStub:
   Description: Checks for stubbed test subjects.
   Enabled: false
 
+RSpec/UnspecifiedException:
+  Description: Checks for a specified error in checking raised errors.
+  Enabled: false
+
 RSpec/VerifiedDoubles:
   Description: 'Prefer using verifying doubles over normal doubles.'
   Enabled: false
@@ -302,14 +322,10 @@ Capybara/FeatureMethods:
   Description: Checks for consistent method usage in feature specs.
   Enabled: false
 
+FactoryBot/AttributeDefinedStatically:
+  Description: Always declare attribute values as blocks.
+  Enabled: false
+
 FactoryBot/CreateList:
   Description: Checks for create_list usage.
   Enabled: true
-
-FactoryBot/DynamicAttributeDefinedStatically:
-  Description: Prefer declaring dynamic attribute values in a block.
-  Enabled: true
-
-FactoryBot/StaticAttributeDefinedDynamically:
-  Description: Prefer declaring static attribute values without a block.
-  Enabled: false

--- a/rubocop-airbnb/lib/rubocop/airbnb/version.rb
+++ b/rubocop-airbnb/lib/rubocop/airbnb/version.rb
@@ -3,6 +3,6 @@
 module RuboCop
   module Airbnb
     # Version information for the the Airbnb RuboCop plugin.
-    VERSION = '1.6.0'.freeze
+    VERSION = '2.0.0'.freeze
   end
 end

--- a/rubocop-airbnb/lib/rubocop/airbnb/version.rb
+++ b/rubocop-airbnb/lib/rubocop/airbnb/version.rb
@@ -3,6 +3,6 @@
 module RuboCop
   module Airbnb
     # Version information for the the Airbnb RuboCop plugin.
-    VERSION = '1.5.0'.freeze
+    VERSION = '1.6.0'.freeze
   end
 end

--- a/rubocop-airbnb/rubocop-airbnb.gemspec
+++ b/rubocop-airbnb/rubocop-airbnb.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
     'Gemfile',
   ]
 
-  spec.add_dependency('rubocop', '0.57.2')
-  spec.add_dependency('rubocop-rspec', '1.27.0')
+  spec.add_dependency('rubocop', '~> 0.58.0')
+  spec.add_dependency('rubocop-rspec', '~> 1.30.0')
   spec.add_development_dependency('rspec', '~> 3.5')
 end


### PR DESCRIPTION
I'm aware this drops support for ruby 2.1, so it might be a non-starter for airbnb. is there an intent to iterate on this gem on the current version and/or to advance the baseline ruby version? @robotpistol @ljharb 