### PR TITLE
Update to work on Ruby 2.6 - new versions of rubocop

### DIFF
--- a/rubocop-airbnb/config/rubocop-layout.yml
+++ b/rubocop-airbnb/config/rubocop-layout.yml
@@ -227,7 +227,7 @@ Layout/FirstMethodParameterLineBreak:
   Enabled: false
 
 # Supports --auto-correct
-Layout/FirstParameterIndentation:
+Layout/IndentFirstArgument:
   Description: Checks the indentation of the first parameter in a method call.
   Enabled: true
   EnforcedStyle: consistent
@@ -238,7 +238,7 @@ Layout/FirstParameterIndentation:
   - special_for_inner_method_call_in_parentheses
 
 # Supports --auto-correct
-Layout/IndentArray:
+Layout/IndentFirstArrayElement:
   Description: Checks the indentation of the first element in an array literal.
   Enabled: true
   EnforcedStyle: consistent
@@ -251,7 +251,7 @@ Layout/IndentAssignment:
   IndentationWidth:
 
 # Supports --auto-correct
-Layout/IndentHash:
+Layout/IndentFirstHashElement:
   Description: Checks the indentation of the first key in a hash literal.
   Enabled: true
   EnforcedStyle: consistent

--- a/rubocop-airbnb/config/rubocop-layout.yml
+++ b/rubocop-airbnb/config/rubocop-layout.yml
@@ -474,11 +474,6 @@ Layout/SpaceInsideBlockBraces:
   EnforcedStyleForEmptyBraces: no_space
   SpaceBeforeBlockParameters: true
 
-Layout/SpaceInsideParens:
-  Description: 'No spaces after ( or before ).'
-  StyleGuide: '#spaces-braces'
-  Enabled: true
-
 Layout/SpaceInsideArrayLiteralBrackets:
   EnforcedStyle: no_space
   SupportedStyles:

--- a/rubocop-airbnb/config/rubocop-lint.yml
+++ b/rubocop-airbnb/config/rubocop-lint.yml
@@ -80,6 +80,11 @@ Lint/EnsureReturn:
 Lint/ErbNewArguments:
   Enabled: false
 
+Lint/FlipFlop:
+  Description: Checks for flip flops
+  StyleGuide: https://github.com/rubocop-hq/ruby-style-guide#no-flip-flops
+  Enabled: false
+
 Lint/FloatOutOfRange:
   Description: Catches floating-point literals too large or small for Ruby to represent.
   Enabled: false
@@ -237,20 +242,20 @@ Lint/UnderscorePrefixedVariableName:
 Lint/UnifiedInteger:
   Enabled: false
 
-Lint/UnneededCopDisableDirective:
+Lint/RedundantCopDisableDirective:
   Description: >-
     Checks for rubocop:disable comments that can be removed.
     Note: this cop is not disabled when disabling all cops. It must be explicitly disabled.
   Enabled: true
 
-Lint/UnneededCopEnableDirective:
+Lint/RedundantCopEnableDirective:
   Description: Checks for rubocop:enable comments that can be removed.
   Enabled: true
 
-Lint/UnneededRequireStatement:
+Lint/RedundantRequireStatement:
   Enabled: false
 
-Lint/UnneededSplatExpansion:
+Lint/RedundantSplatExpansion:
   Enabled: false
 
 Lint/UnreachableCode:

--- a/rubocop-airbnb/config/rubocop-performance.yml
+++ b/rubocop-airbnb/config/rubocop-performance.yml
@@ -57,11 +57,6 @@ Performance/InefficientHashSearch:
   Enabled: false
 
 # Supports --auto-correct
-Performance/LstripRstrip:
-  Description: Use `strip` instead of `lstrip.rstrip`.
-  Enabled: false
-
-# Supports --auto-correct
 Performance/RangeInclude:
   Description: Use `Range#cover?` instead of `Range#include?`.
   Reference: https://github.com/JuanitoFatas/fast-ruby#cover-vs-include-code
@@ -120,9 +115,6 @@ Performance/TimesMap:
   Enabled: false
 
 Performance/UnfreezeString:
-  Enabled: false
-
-Performance/UnneededSort:
   Enabled: false
 
 Performance/UriDefaultParser:

--- a/rubocop-airbnb/config/rubocop-performance.yml
+++ b/rubocop-airbnb/config/rubocop-performance.yml
@@ -85,11 +85,6 @@ Performance/RedundantMerge:
   Reference: https://github.com/JuanitoFatas/fast-ruby#hashmerge-vs-hash-code
   Enabled: false
 
-# Supports --auto-correct
-Performance/RedundantSortBy:
-  Description: Use `sort` instead of `sort_by { |x| x }`.
-  Enabled: false
-
 Performance/RegexpMatch:
   Enabled: false
 
@@ -97,12 +92,6 @@ Performance/RegexpMatch:
 Performance/ReverseEach:
   Description: Use `reverse_each` instead of `reverse.each`.
   Reference: https://github.com/JuanitoFatas/fast-ruby#enumerablereverseeach-vs-enumerablereverse_each-code
-  Enabled: false
-
-# Supports --auto-correct
-Performance/Sample:
-  Description: Use `sample` instead of `shuffle.first`, `shuffle.last`, and `shuffle[Fixnum]`.
-  Reference: https://github.com/JuanitoFatas/fast-ruby#arrayshufflefirst-vs-arraysample-code
   Enabled: false
 
 # Supports --auto-correct

--- a/rubocop-airbnb/config/rubocop-rails.yml
+++ b/rubocop-airbnb/config/rubocop-rails.yml
@@ -170,9 +170,6 @@ Rails/RequestReferer:
 Rails/ReversibleMigration:
   Enabled: false
 
-Rails/SafeNavigation:
-  Enabled: false
-
 Rails/SaveBang:
   Enabled: false
 

--- a/rubocop-airbnb/config/rubocop-style.yml
+++ b/rubocop-airbnb/config/rubocop-style.yml
@@ -862,6 +862,11 @@ Style/StringMethods:
   PreferredMethods:
     intern: to_sym
 
+# Supports --auto-correct
+Style/Strip:
+  Description: Use `strip` instead of `lstrip.rstrip`.
+  Enabled: false
+
 Style/StructInheritance:
   Description: Checks for inheritance from Struct.new.
   StyleGuide: https://github.com/rubocop-hq/ruby-style-guide#no-extend-struct-new
@@ -944,6 +949,9 @@ Style/RedundantInterpolation:
 Style/RedundantPercentQ:
   Description: Checks for %q/%Q when single quotes or double quotes would do.
   StyleGuide: https://github.com/rubocop-hq/ruby-style-guide#percent-q
+  Enabled: false
+
+Style/RedundantSort:
   Enabled: false
 
 Style/UnpackFirst:

--- a/rubocop-airbnb/config/rubocop-style.yml
+++ b/rubocop-airbnb/config/rubocop-style.yml
@@ -328,11 +328,6 @@ Style/ExpandPathArguments:
   Description: "Use `expand_path(__dir__)` instead of `expand_path('..', __FILE__)`."
   Enabled: false
 
-Style/FlipFlop:
-  Description: Checks for flip flops
-  StyleGuide: https://github.com/rubocop-hq/ruby-style-guide#no-flip-flops
-  Enabled: false
-
 Style/For:
   Description: Checks use of for or each in multiline loops.
   StyleGuide: https://github.com/rubocop-hq/ruby-style-guide#no-for-loops
@@ -360,7 +355,7 @@ Style/FrozenStringLiteralComment:
   Description: Add the frozen_string_literal comment to the top of files to help transition
     from Ruby 2.3.0 to Ruby 3.0.
   Enabled: false
-  EnforcedStyle: when_needed
+  EnforcedStyle: always
   SupportedStyles:
   - when_needed
   - always
@@ -736,6 +731,11 @@ Style/RedundantSelf:
   Enabled: true
 
 # Supports --auto-correct
+Style/RedundantSortBy:
+  Description: Use `sort` instead of `sort_by { |x| x }`.
+  Enabled: false
+
+# Supports --auto-correct
 Style/RegexpLiteral:
   Description: Use / or %r around regular expressions.
   StyleGuide: https://github.com/rubocop-hq/ruby-style-guide#percent-r
@@ -761,6 +761,12 @@ Style/ReturnNil:
   Enabled: false
 
 Style/SafeNavigation:
+  Enabled: false
+
+# Supports --auto-correct
+Style/Sample:
+  Description: Use `sample` instead of `shuffle.first`, `shuffle.last`, and `shuffle[Fixnum]`.
+  Reference: https://github.com/JuanitoFatas/fast-ruby#arrayshufflefirst-vs-arraysample-code
   Enabled: false
 
 # Supports --auto-correct
@@ -922,20 +928,20 @@ Style/UnlessElse:
   Enabled: true
 
 # Supports --auto-correct
-Style/UnneededCapitalW:
+Style/RedundantCapitalW:
   Description: Checks for %W when interpolation is not needed.
   Enabled: false
 
-Style/UnneededCondition:
+Style/RedundantCondition:
   Enabled: false
 
 # Supports --auto-correct
-Style/UnneededInterpolation:
+Style/RedundantInterpolation:
   Description: Checks for strings that are just an interpolated expression.
   Enabled: false
 
 # Supports --auto-correct
-Style/UnneededPercentQ:
+Style/RedundantPercentQ:
   Description: Checks for %q/%Q when single quotes or double quotes would do.
   StyleGuide: https://github.com/rubocop-hq/ruby-style-guide#percent-q
   Enabled: false

--- a/rubocop-airbnb/lib/rubocop/cop/airbnb/continuation_slash.rb
+++ b/rubocop-airbnb/lib/rubocop/cop/airbnb/continuation_slash.rb
@@ -14,7 +14,7 @@ module RuboCop
         alias on_send enforce_violation
         alias on_if enforce_violation
 
-        Util::ASGN_NODES.each do |type|
+        AST::Node::ASSIGNMENTS.each do |type|
           define_method("on_#{type}") do |node|
             enforce_violation(node)
           end

--- a/rubocop-airbnb/lib/rubocop/cop/airbnb/continuation_slash.rb
+++ b/rubocop-airbnb/lib/rubocop/cop/airbnb/continuation_slash.rb
@@ -14,7 +14,10 @@ module RuboCop
         alias on_send enforce_violation
         alias on_if enforce_violation
 
-        AST::Node::ASSIGNMENTS.each do |type|
+        rubocop_version = Gem.loaded_specs.fetch('rubocop', nil)&.version.to_s
+        assignments = rubocop_version.to_f >= 0.59 ? AST::Node::ASSIGNMENTS : Util::ASGN_NODES
+
+        assignments.each do |type|
           define_method("on_#{type}") do |node|
             enforce_violation(node)
           end

--- a/rubocop-airbnb/lib/rubocop/cop/airbnb/continuation_slash.rb
+++ b/rubocop-airbnb/lib/rubocop/cop/airbnb/continuation_slash.rb
@@ -14,10 +14,13 @@ module RuboCop
         alias on_send enforce_violation
         alias on_if enforce_violation
 
-        rubocop_version = Gem.loaded_specs.fetch('rubocop', nil)&.version.to_s
-        assignments = rubocop_version.to_f >= 0.59 ? AST::Node::ASSIGNMENTS : Util::ASGN_NODES
+        assignments = if Gem.loaded_specs['rubocop'].version < Gem::Version.new('0.59.0')
+          RuboCop::Util::ASGN_NODES
+        else
+          RuboCop::AST::Node::ASSIGNMENTS
+        end
 
-        assignments.each do |type|
+         assignments.each do |type|
           define_method("on_#{type}") do |node|
             enforce_violation(node)
           end

--- a/rubocop-airbnb/lib/rubocop/cop/airbnb/spec_constant_assignment.rb
+++ b/rubocop-airbnb/lib/rubocop/cop/airbnb/spec_constant_assignment.rb
@@ -1,4 +1,6 @@
+require 'rubocop-performance'
 require 'rubocop-rspec'
+require 'rubocop-rails'
 
 module RuboCop
   module Cop

--- a/rubocop-airbnb/rubocop-airbnb.gemspec
+++ b/rubocop-airbnb/rubocop-airbnb.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
     'Gemfile',
   ]
 
-  spec.add_dependency('rubocop', '~> 0.58.0')
-  spec.add_dependency('rubocop-rspec', '~> 1.30.0')
-  spec.add_development_dependency('rspec', '~> 3.5')
+  spec.add_dependency('rubocop', '~> 0.62.0')
+  spec.add_dependency('rubocop-rspec', '~> 1.31.0')
+  spec.add_development_dependency('rspec', '~> 3.8')
 end

--- a/rubocop-airbnb/rubocop-airbnb.gemspec
+++ b/rubocop-airbnb/rubocop-airbnb.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
     'Gemfile',
   ]
 
-  spec.add_dependency('rubocop', '~> 0.62.0')
-  spec.add_dependency('rubocop-rspec', '~> 1.31.0')
-  spec.add_development_dependency('rspec', '~> 3.8')
+  spec.add_dependency('rubocop', '~> 0.76.0')
+  spec.add_dependency('rubocop-rspec', '~> 1.36.0')
+  spec.add_development_dependency('rspec', '~> 3.9')
 end

--- a/rubocop-airbnb/rubocop-airbnb.gemspec
+++ b/rubocop-airbnb/rubocop-airbnb.gemspec
@@ -27,5 +27,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency('rubocop', '~> 0.76.0')
   spec.add_dependency('rubocop-rspec', '~> 1.36.0')
+  spec.add_dependency('rubocop-rails', '~> 2.3.2')
+  spec.add_dependency('rubocop-performance', '~> 1.5.0')
   spec.add_development_dependency('rspec', '~> 3.9')
 end


### PR DESCRIPTION
I know this can't be merged into the master branch because of Airbnb main app restrictions (I think I've read it's using Ruby 2.1 and the latest version of rubocop just accepts 2.2+) but I think having an updated PR that works on Ruby 2.6 can be useful for people that have upgraded their version of Ruby and they still want to use your rubocop ruleset.

Don't hesitate to close this PR if you think this is not appropriate or useful.

Thanks for your work!