### PR TITLE
Update Dependant RuboCop version to allow for newer versions of Ruby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ rvm:
   - 2.3
   - 2.4
   - 2.5
+  - 2.6
 install:
   - cd rubocop-airbnb
   - bundle install

--- a/rubocop-airbnb/lib/rubocop/cop/airbnb/continuation_slash.rb
+++ b/rubocop-airbnb/lib/rubocop/cop/airbnb/continuation_slash.rb
@@ -14,7 +14,13 @@ module RuboCop
         alias on_send enforce_violation
         alias on_if enforce_violation
 
-        Util::ASGN_NODES.each do |type|
+        assignments =
+          if Gem.loaded_specs['rubocop'].version < Gem::Version.new('0.59.0')
+            RuboCop::Util::ASGN_NODES
+          else
+            RuboCop::AST::Node::ASSIGNMENTS
+          end
+        assignments.each do |type|
           define_method("on_#{type}") do |node|
             enforce_violation(node)
           end

--- a/rubocop-airbnb/rubocop-airbnb.gemspec
+++ b/rubocop-airbnb/rubocop-airbnb.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
     'Gemfile',
   ]
 
-  spec.add_dependency('rubocop', '~> 0.58.0')
-  spec.add_dependency('rubocop-rspec', '~> 1.30.0')
-  spec.add_development_dependency('rspec', '~> 3.5')
+  spec.add_dependency('rubocop', '~> 0.62.0')
+  spec.add_dependency('rubocop-rspec', '~> 1.31.0')
+  spec.add_development_dependency('rspec', '~> 3.8')
 end


### PR DESCRIPTION
Creates an assignment variable, to allow checking of which method of assignment to use based on which version of rubocop is running (v.0.59.0 introduced the RuboCop::AST::Node::ASSIGNMENTS over the older RuboCop::Util::ASGN_NODES). This should preserve backwards compatibility while allowing for the newer rubocop versions which support v2.6 ruby.

This follows from the commentary on #150 (making use of the idea suggested in the comments by @robotpistol ).