### PR TITLE
Add symbols as valid class names

### DIFF
--- a/rubocop-airbnb/lib/rubocop/cop/airbnb/class_name.rb
+++ b/rubocop-airbnb/lib/rubocop/cop/airbnb/class_name.rb
@@ -9,7 +9,7 @@ module RuboCop
           'reloading of zeus after changing a model.'.freeze
 
         # Is this a has_many, has_one, or belongs_to with a :class_name arg? Make sure the
-        # class name is a hardcoded string. If not, add an offense and return true.
+        # class name is a hardcoded string or symbol. If not, add an offense and return true.
         def on_send(node)
           association_statement =
             node.command?(:has_many) ||
@@ -20,7 +20,7 @@ module RuboCop
 
           class_pair = class_name_node(node)
 
-          if class_pair && !string_class_name?(class_pair)
+          if class_pair && !valid_class_name?(class_pair)
             add_offense(class_pair)
           end
         end
@@ -37,9 +37,10 @@ module RuboCop
           end
         end
 
-        # Given a hash pair :class_name => value, is the value a hardcoded string?
-        def string_class_name?(class_pair)
-          class_pair.children[1].str_type?
+        # Given a hash pair :class_name => value, is the value a hardcoded string or symbol?
+        def valid_class_name?(class_pair)
+          name = class_pair.children[1]
+          name.str_type? || name.sym_type?
         end
       end
     end

--- a/rubocop-airbnb/lib/rubocop/cop/airbnb/factory_class_use_string.rb
+++ b/rubocop-airbnb/lib/rubocop/cop/airbnb/factory_class_use_string.rb
@@ -12,7 +12,7 @@ module RuboCop
 
           class_pair = class_node(node)
 
-          if class_pair && !string_class_name?(class_pair)
+          if class_pair && !valid_class_name?(class_pair)
             add_offense(class_pair)
           end
         end
@@ -29,9 +29,10 @@ module RuboCop
           end
         end
 
-        # Given a hash pair :class_name => value, is the value a hardcoded string?
-        def string_class_name?(class_pair)
-          class_pair.children[1].str_type?
+        # Given a hash pair :class_name => value, is the value a hardcoded string or symbol?
+        def valid_class_name?(class_pair)
+          name = class_pair.children[1]
+          name.str_type? || name.sym_type?
         end
       end
     end

--- a/rubocop-airbnb/spec/rubocop/cop/airbnb/class_name_spec.rb
+++ b/rubocop-airbnb/spec/rubocop/cop/airbnb/class_name_spec.rb
@@ -24,6 +24,17 @@ describe RuboCop::Cop::Airbnb::ClassName do
 
       expect(cop.offenses).to be_empty
     end
+
+    it 'passes with :Model' do
+      source = [
+        'class Coupon',
+        '  belongs_to :user, :class_name => :User',
+        'end',
+      ].join("\n")
+      inspect_source(source)
+
+      expect(cop.offenses).to be_empty
+    end
   end
 
   describe "has_many" do
@@ -49,6 +60,17 @@ describe RuboCop::Cop::Airbnb::ClassName do
 
       expect(cop.offenses).to be_empty
     end
+
+    it 'passes with :Model' do
+      source = [
+        'class Coupon',
+        '  has_many :reservations, :class_name => :Reservation2',
+        'end',
+      ].join("\n")
+      inspect_source(source)
+
+      expect(cop.offenses).to be_empty
+    end
   end
 
   describe "has_one" do
@@ -68,6 +90,17 @@ describe RuboCop::Cop::Airbnb::ClassName do
       source = [
         'class Coupon',
         '  has_one :loss, :class_name => "Payments::Loss"',
+        'end',
+      ].join("\n")
+      inspect_source(source)
+
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'passes with :Model' do
+      source = [
+        'class Coupon',
+        '  has_one :loss, :class_name => :Payments',
         'end',
       ].join("\n")
       inspect_source(source)

--- a/rubocop-airbnb/spec/rubocop/cop/airbnb/factory_class_use_string_spec.rb
+++ b/rubocop-airbnb/spec/rubocop/cop/airbnb/factory_class_use_string_spec.rb
@@ -23,4 +23,15 @@ describe RuboCop::Cop::Airbnb::FactoryClassUseString do
 
     expect(cop.offenses).to be_empty
   end
+
+  it 'passes with :class => :Model' do
+    source = [
+      'factory :help_answer, :class => :Answer do',
+      '  text { Faker::Company.name }',
+      'end',
+    ].join("\n")
+    inspect_source(source)
+
+    expect(cop.offenses).to be_empty
+  end
 end


### PR DESCRIPTION
Allows symbols to be used as class names

https://github.com/airbnb/ruby/issues/159