### PR TITLE
Require gems in library code

### DIFF
--- a/rubocop-airbnb/.rubocop.yml
+++ b/rubocop-airbnb/.rubocop.yml
@@ -1,6 +1,3 @@
-require:
-  - rubocop-performance
-  - rubocop-rails
 inherit_from:
   - .rubocop_airbnb.yml
   - ./config/default.yml

--- a/rubocop-airbnb/CHANGELOG.md
+++ b/rubocop-airbnb/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 3.02
+* Moves `require`s for `rubocop-performance` and `rubocop-rails` to library code for better transitivity.
+
 # 3.0.1
 * Update supported ruby versions in gemspec
 

--- a/rubocop-airbnb/lib/rubocop-airbnb.rb
+++ b/rubocop-airbnb/lib/rubocop-airbnb.rb
@@ -4,6 +4,9 @@ require 'yaml'
 # Load original rubocop gem
 require 'rubocop'
 
+require 'rubocop-performance'
+require 'rubocop-rails'
+
 require 'rubocop/airbnb'
 require 'rubocop/airbnb/inject'
 require 'rubocop/airbnb/version'

--- a/rubocop-airbnb/lib/rubocop/airbnb/version.rb
+++ b/rubocop-airbnb/lib/rubocop/airbnb/version.rb
@@ -3,6 +3,6 @@
 module RuboCop
   module Airbnb
     # Version information for the the Airbnb RuboCop plugin.
-    VERSION = '3.0.1'
+    VERSION = '3.0.2'
   end
 end


### PR DESCRIPTION
If you depend on this configuration through ruby code rather than through rubocop `.yml` dependencies this change means you don't need to explicitly pull in the `rubocop-performance` and `rubocop-rails` gems in your `yml` files.