### PR TITLE
Disable rescue alignment cop until bugs are fixed

### DIFF
--- a/rubocop-airbnb/CHANGELOG.md
+++ b/rubocop-airbnb/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 3.1.0
+* Disable Layout/RescueEnsureAlignment
+
 # 3.0.2
 * Moves `require`s for `rubocop-performance` and `rubocop-rails` to library code for better transitivity.
 

--- a/rubocop-airbnb/config/rubocop-layout.yml
+++ b/rubocop-airbnb/config/rubocop-layout.yml
@@ -363,7 +363,7 @@ Layout/MultilineOperationIndentation:
 # Supports --auto-correct
 Layout/RescueEnsureAlignment:
   Description: Align rescues and ensures correctly.
-  Enabled: true
+  Enabled: false
 
 # Supports --auto-correct
 Layout/SpaceAfterColon:

--- a/rubocop-airbnb/lib/rubocop/airbnb/version.rb
+++ b/rubocop-airbnb/lib/rubocop/airbnb/version.rb
@@ -3,6 +3,6 @@
 module RuboCop
   module Airbnb
     # Version information for the the Airbnb RuboCop plugin.
-    VERSION = '3.0.2'
+    VERSION = '3.1.0'
   end
 end


### PR DESCRIPTION
Currently the rescue alignment cop has an issue on variable assignments where it enforces this style:
```
return_val = begin
  # computation
             rescue
               # rescued value
end
```
which is bad. 

https://github.com/rubocop-hq/rubocop/pull/7531 will maybe fix it, but I think it makes sense to disable this for now until it's fixed in a rubocop release.