### PR TITLE
Update to Rubocop 0.80

### DIFF
--- a/rubocop-airbnb/CHANGELOG.md
+++ b/rubocop-airbnb/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.0.3
+* Update to rubocop 0.80
+* Disable Style/BracesAroundHashParameters
+
 # 3.0.2
 * Moves `require`s for `rubocop-performance` and `rubocop-rails` to library code for better transitivity.
 

--- a/rubocop-airbnb/CHANGELOG.md
+++ b/rubocop-airbnb/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 3.0.3
+# Unreleased
 * Update to rubocop 0.80
 * Disable Style/BracesAroundHashParameters
 

--- a/rubocop-airbnb/config/rubocop-layout.yml
+++ b/rubocop-airbnb/config/rubocop-layout.yml
@@ -11,13 +11,13 @@ Layout/AccessModifierIndentation:
   - indent
 
 # Supports --auto-correct
-Layout/AlignArray:
+Layout/ArrayAlignment:
   Description: Align the elements of an array literal if they span more than one line.
   StyleGuide: https://github.com/rubocop-hq/ruby-style-guide#align-multiline-arrays
   Enabled: true
 
 # Supports --auto-correct
-Layout/AlignHash:
+Layout/HashAlignment:
   Description: Align the elements of a hash literal if they span more than one line.
   Enabled: true
   EnforcedHashRocketStyle: key
@@ -30,7 +30,7 @@ Layout/AlignHash:
   - ignore_explicit
 
 # Supports --auto-correct
-Layout/AlignParameters:
+Layout/ParameterAlignment:
   Description: Align the parameters of a method call if they span more than one line.
   StyleGuide: https://github.com/rubocop-hq/ruby-style-guide#no-double-indent
   Enabled: true
@@ -227,7 +227,7 @@ Layout/FirstMethodParameterLineBreak:
   Enabled: false
 
 # Supports --auto-correct
-Layout/IndentFirstArgument:
+Layout/FirstArgumentIndentation:
   Description: Checks the indentation of the first parameter in a method call.
   Enabled: true
   EnforcedStyle: consistent
@@ -238,19 +238,19 @@ Layout/IndentFirstArgument:
   - special_for_inner_method_call_in_parentheses
 
 # Supports --auto-correct
-Layout/IndentFirstArrayElement:
+Layout/FirstArrayElementIndentation:
   Description: Checks the indentation of the first element in an array literal.
   Enabled: true
   EnforcedStyle: consistent
 
 # Supports --auto-correct
-Layout/IndentAssignment:
+Layout/AssignmentIndentation:
   Description: Checks the indentation of the first line of the right-hand-side of a
     multi-line assignment.
   Enabled: true
 
 # Supports --auto-correct
-Layout/IndentFirstHashElement:
+Layout/FirstHashElementIndentation:
   Description: Checks the indentation of the first key in a hash literal.
   Enabled: true
   EnforcedStyle: consistent
@@ -258,7 +258,7 @@ Layout/IndentFirstHashElement:
   - special_inside_parentheses
   - consistent
 
-Layout/IndentHeredoc:
+Layout/HeredocIndentation:
   Enabled: false
 
 # Supports --auto-correct
@@ -282,7 +282,7 @@ Layout/InitialIndentation:
   Description: Checks the indentation of the first non-blank non-comment line in a file.
   Enabled: true
 
-Layout/LeadingBlankLines:
+Layout/LeadingEmptyLines:
   Enabled: true
 
 # Supports --auto-correct
@@ -537,7 +537,7 @@ Layout/Tab:
   Enabled: true
 
 # Supports --auto-correct
-Layout/TrailingBlankLines:
+Layout/TrailingEmptyLines:
   Description: Checks trailing blank lines and final newline.
   StyleGuide: https://github.com/rubocop-hq/ruby-style-guide#newline-eof
   Enabled: true
@@ -552,5 +552,5 @@ Layout/TrailingWhitespace:
   StyleGuide: https://github.com/rubocop-hq/ruby-style-guide#no-trailing-whitespace
   Enabled: true
 
-Layout/IndentFirstParameter:
+Layout/FirstParameterIndentation:
   Enabled: true

--- a/rubocop-airbnb/config/rubocop-lint.yml
+++ b/rubocop-airbnb/config/rubocop-lint.yml
@@ -45,7 +45,7 @@ Lint/DuplicateMethods:
   Description: Check for duplicate methods calls.
   Enabled: true
 
-Lint/DuplicatedKey:
+Lint/DuplicateHashKey:
   Description: Check for duplicate keys in hash literals.
   Enabled: true
 
@@ -93,7 +93,7 @@ Lint/FormatParameterMismatch:
   Description: The number of parameters to format/sprint must match the fields.
   Enabled: true
 
-Lint/HandleExceptions:
+Lint/SuppressedException:
   Description: Don't suppress exception.
   StyleGuide: https://github.com/rubocop-hq/ruby-style-guide#dont-hide-exceptions
   Enabled: false
@@ -144,7 +144,7 @@ Lint/MissingCopEnableDirective:
   Description: 'Checks for a `# rubocop:enable` after `# rubocop:disable`'
   Enabled: true
 
-Lint/MultipleCompare:
+Lint/MultipleComparison:
   Enabled: false
 
 Lint/NestedMethodDefinition:
@@ -230,7 +230,7 @@ Lint/ShadowingOuterLocalVariable:
   Enabled: true
 
 # Supports --auto-correct
-Lint/StringConversionInInterpolation:
+Lint/RedundantStringCoercion:
   Description: Checks for Object#to_s usage in string interpolation.
   StyleGuide: https://github.com/rubocop-hq/ruby-style-guide#no-to-s
   Enabled: true

--- a/rubocop-airbnb/config/rubocop-metrics.yml
+++ b/rubocop-airbnb/config/rubocop-metrics.yml
@@ -21,7 +21,7 @@ Metrics/CyclomaticComplexity:
   Enabled: false
   Max: 6
 
-Metrics/LineLength:
+Layout/LineLength:
   Max: 100
   AllowURI: true
 

--- a/rubocop-airbnb/config/rubocop-naming.yml
+++ b/rubocop-airbnb/config/rubocop-naming.yml
@@ -55,18 +55,18 @@ Naming/PredicateName:
   - is_
   - has_
   - have_
-  NamePrefixBlacklist:
+  ForbiddenPrefixes:
   - is_
   - has_
   - have_
 
-Naming/UncommunicativeBlockParamName:
+Naming/BlockParameterName:
   Description: >-
               Checks for block parameter names that contain capital letters,
               end in numbers, or do not meet a minimal length.
   Enabled: false
 
-Naming/UncommunicativeMethodParamName:
+Naming/MethodParameterName:
   Description: >-
               Checks for method parameter names that contain capital letters,
               end in numbers, or do not meet a minimal length.

--- a/rubocop-airbnb/config/rubocop-style.yml
+++ b/rubocop-airbnb/config/rubocop-style.yml
@@ -134,16 +134,6 @@ Style/BlockDelimiters:
     - proc
     - it
 
-# Supports --auto-correct
-Style/BracesAroundHashParameters:
-  Description: Enforce braces style around hash parameters.
-  Enabled: false
-  EnforcedStyle: no_braces
-  SupportedStyles:
-  - braces
-  - no_braces
-  - context_dependent
-
 Style/CaseEquality:
   Description: Avoid explicit use of the case equality operator(===).
   StyleGuide: https://github.com/rubocop-hq/ruby-style-guide#no-case-equality

--- a/rubocop-airbnb/lib/rubocop/airbnb/version.rb
+++ b/rubocop-airbnb/lib/rubocop/airbnb/version.rb
@@ -3,6 +3,6 @@
 module RuboCop
   module Airbnb
     # Version information for the the Airbnb RuboCop plugin.
-    VERSION = '3.0.2'
+    VERSION = '3.0.3'
   end
 end

--- a/rubocop-airbnb/lib/rubocop/airbnb/version.rb
+++ b/rubocop-airbnb/lib/rubocop/airbnb/version.rb
@@ -3,6 +3,6 @@
 module RuboCop
   module Airbnb
     # Version information for the the Airbnb RuboCop plugin.
-    VERSION = '3.0.3'
+    VERSION = '3.0.2'
   end
 end

--- a/rubocop-airbnb/rubocop-airbnb.gemspec
+++ b/rubocop-airbnb/rubocop-airbnb.gemspec
@@ -25,9 +25,9 @@ Gem::Specification.new do |spec|
     'Gemfile',
   ]
 
-  spec.add_dependency('rubocop', '~> 0.76.0')
+  spec.add_dependency('rubocop', '~> 0.80.0')
   spec.add_dependency('rubocop-performance', '~> 1.5.0')
-  spec.add_dependency('rubocop-rails', '~> 2.3.2')
-  spec.add_dependency('rubocop-rspec', '~> 1.30.0')
+  spec.add_dependency('rubocop-rails', '~> 2.4.2')
+  spec.add_dependency('rubocop-rspec', '~> 1.38.1')
   spec.add_development_dependency('rspec', '~> 3.5')
 end


### PR DESCRIPTION
This will add support for Rubocop 0.80. 
Some cops were rename on this new version.