### PR TITLE
Update Layout/IndentationConsistency SupportedStyles

### DIFF
--- a/rubocop-airbnb/config/rubocop-layout.yml
+++ b/rubocop-airbnb/config/rubocop-layout.yml
@@ -268,7 +268,7 @@ Layout/IndentationConsistency:
   EnforcedStyle: normal
   SupportedStyles:
   - normal
-  - rails
+  - indented_internal_methods
 
 # Supports --auto-correct
 Layout/IndentationWidth:


### PR DESCRIPTION
Rubocop changed the `rails` style for `Layout/IndentationConsistency` to `indented_internal_methods` in version 0.72:
https://github.com/rubocop-hq/rubocop/pull/7113

Since rubocop-airbnb requires rubocop 0.76 selecting this style is broken. Using `rails` results in the error message:
```
Error: obsolete `EnforcedStyle: rails` (for Layout/IndentationConsistency) found in .rubocop.yml
`EnforcedStyle: rails` has been renamed to `EnforcedStyle: indented_internal_methods`
```
And using `indented_internal_methods` results in:
```
Error: invalid EnforcedStyle 'indented_internal_methods' for Layout/IndentationConsistency found in .rubocop.yml
Valid choices are: normal, rails
```