### PR TITLE
Correct 0.80 cops

### DIFF
--- a/rubocop-airbnb/config/rubocop-layout.yml
+++ b/rubocop-airbnb/config/rubocop-layout.yml
@@ -554,3 +554,8 @@ Layout/TrailingWhitespace:
 
 Layout/FirstParameterIndentation:
   Enabled: true
+
+# Supports --auto-correct
+Layout/LineLength:
+  Max: 100
+  AllowURI: true

--- a/rubocop-airbnb/config/rubocop-metrics.yml
+++ b/rubocop-airbnb/config/rubocop-metrics.yml
@@ -21,10 +21,6 @@ Metrics/CyclomaticComplexity:
   Enabled: false
   Max: 6
 
-Layout/LineLength:
-  Max: 100
-  AllowURI: true
-
 Metrics/MethodLength:
   Enabled: false
 

--- a/rubocop-airbnb/config/rubocop-rails.yml
+++ b/rubocop-airbnb/config/rubocop-rails.yml
@@ -212,3 +212,7 @@ Rails/IgnoredSkipActionFilterOption:
 
 Rails/ReflectionClassName:
   Enabled: true
+
+Rails/RakeEnvironment:
+  Description: Ensures that rake tasks depend on :environment
+  Enabled: false

--- a/rubocop-airbnb/config/rubocop-style.yml
+++ b/rubocop-airbnb/config/rubocop-style.yml
@@ -814,6 +814,21 @@ Style/SpecialGlobalVars:
   StyleGuide: https://github.com/rubocop-hq/ruby-style-guide#no-cryptic-perlisms
   Enabled: true
 
+Style/HashEachMethods:
+  Description: Enforce use of each_key and each_value Hash methods.
+  StyleGuide: https://docs.rubocop.org/en/latest/cops_style/#stylehasheachmethods
+  Enabled: false
+
+Style/HashTransformKeys:
+  Description: Enforce use of transform_keys Hash methods. Not suggested for use below ruby 2.5
+  StyleGuide: https://docs.rubocop.org/en/latest/cops_style/#stylehashtransformkeys 
+  Enabled: false
+
+Style/HashTransformValues:
+  Description: Enforce use of transform_values Hash methods. Not suggested for use below ruby 2.5
+  StyleGuide: https://docs.rubocop.org/en/latest/cops_style/#stylehashtransformvalues
+  Enabled: false
+
 Style/StabbyLambdaParentheses:
   Description: Check for the usage of parentheses around stabby lambda arguments.
   StyleGuide: https://github.com/rubocop-hq/ruby-style-guide#stabby-lambda-with-args


### PR DESCRIPTION
These are some of the new cops for 0.80. Here are my rationale for disabling them:

`Rails/RakeEnvironment` -- this dependency is not needed for all rake tasks, so it should not be enforced for all of them.

`Style/HashEachMethods` -- this has an unsafe autocorrect which seems dangerous.

`Style/HashTransformValues` and `Style/HashTransformKeys` should only be used with ruby >= 2.5, which is undesirable. 