### PR TITLE
Support ruby 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,11 @@ cache:
   bundler: true
 sudo: false
 rvm:
-  - 2.3
   - 2.4
   - 2.5
   - 2.6
+  - 2.7
+  - 3.0
 install:
   - cd rubocop-airbnb
   - bundle install

--- a/rubocop-airbnb/CHANGELOG.md
+++ b/rubocop-airbnb/CHANGELOG.md
@@ -3,7 +3,11 @@
 * Run CI against Ruby 2.7
 * Drop support for Ruby 2.3
 * Update rubocop to 0.93.1
+* Update rubocop-performance to 1.10.2
+* Update rubocop-rails to 2.9.1
+* Update rubocop-rspec to 1.44.1
 * Disable Style/BracesAroundHashParameters
+* Set `DisabledByDefault: true` to disable any new rubocop cops that have not yet been evaluated for this style guide
 
 # 3.0.2
 * Moves `require`s for `rubocop-performance` and `rubocop-rails` to library code for better transitivity.

--- a/rubocop-airbnb/CHANGELOG.md
+++ b/rubocop-airbnb/CHANGELOG.md
@@ -1,5 +1,8 @@
-# Unreleased
-* Update to rubocop 0.80
+# 4.0.0
+* Add support for Ruby 3.0
+* Run CI against Ruby 2.7
+* Drop support for Ruby 2.3
+* Update rubocop to 0.93.1
 * Disable Style/BracesAroundHashParameters
 
 # 3.0.2

--- a/rubocop-airbnb/config/default.yml
+++ b/rubocop-airbnb/config/default.yml
@@ -24,6 +24,15 @@ AllCops:
     - spec/factories/**/*.rb
     - features/support/factories/**/*.rb
 
+  # While Rubocop has released a bunch of new cops, not all of these cops have been evaluated as
+  # part of this styleguide. To prevent new, unevaluated cops from imposing on this styleguide, we
+  # are marking these new cops as disabled. Note that as a consumer of this styleguide, you can
+  # always override any choices here by setting `Enabled: true` on any cops that you would like to
+  # have be enabled, even if we have explicitly disabled them (or if they are new and we have yet
+  # to evaluate them). For more on this configuration parameter, see
+  # https://github.com/rubocop/rubocop/blob/1e55b1aa5e4c5eaeccad5d61f08b7930ed6bc341/config/default.yml#L89-L101
+  DisabledByDefault: true
+
 inherit_from:
   - './rubocop-airbnb.yml'
   - './rubocop-bundler.yml'

--- a/rubocop-airbnb/config/rubocop-layout.yml
+++ b/rubocop-airbnb/config/rubocop-layout.yml
@@ -531,7 +531,7 @@ Layout/SpaceInsideStringInterpolation:
   - no_space
 
 # Supports --auto-correct
-Layout/Tab:
+Layout/IndentationStyle:
   Description: No hard tabs.
   StyleGuide: https://github.com/rubocop-hq/ruby-style-guide#spaces-indentation
   Enabled: true

--- a/rubocop-airbnb/config/rubocop-lint.yml
+++ b/rubocop-airbnb/config/rubocop-lint.yml
@@ -68,10 +68,6 @@ Lint/EmptyInterpolation:
 Lint/EmptyWhen:
   Enabled: false
 
-Lint/EndInMethod:
-  Description: END blocks should not be placed inside method definitions.
-  Enabled: false
-
 Lint/EnsureReturn:
   Description: Do not use return in an ensure block.
   StyleGuide: https://github.com/rubocop-hq/ruby-style-guide#no-return-ensure
@@ -143,6 +139,9 @@ Lint/MissingCopEnableDirective:
   MaximumRangeSize: .inf
   Description: 'Checks for a `# rubocop:enable` after `# rubocop:disable`'
   Enabled: true
+
+Lint/MissingSuper:
+  Enabled: false
 
 Lint/MultipleComparison:
   Enabled: false
@@ -289,7 +288,7 @@ Lint/UselessAssignment:
   StyleGuide: https://github.com/rubocop-hq/ruby-style-guide#underscore-unused-vars
   Enabled: true
 
-Lint/UselessComparison:
+Lint/BinaryOperatorWithIdenticalOperands:
   Description: Checks for comparison of something with itself.
   Enabled: true
 

--- a/rubocop-airbnb/config/rubocop-style.yml
+++ b/rubocop-airbnb/config/rubocop-style.yml
@@ -347,8 +347,9 @@ Style/FrozenStringLiteralComment:
   Enabled: false
   SupportedStyles:
   - always
+  - always_true
   - never
-  EnforcedStyle: always
+  EnforcedStyle: always_true
 
 Style/GlobalVars:
   Description: Do not introduce global variables.
@@ -447,9 +448,6 @@ Style/MethodDefParentheses:
   SupportedStyles:
   - require_parentheses
   - require_no_parentheses
-
-Style/MethodMissingSuper:
-  Enabled: false
 
 Style/MissingRespondToMissing:
   Enabled: false
@@ -821,7 +819,7 @@ Style/HashEachMethods:
 
 Style/HashTransformKeys:
   Description: Enforce use of transform_keys Hash methods. Not suggested for use below ruby 2.5
-  StyleGuide: https://docs.rubocop.org/en/latest/cops_style/#stylehashtransformkeys 
+  StyleGuide: https://docs.rubocop.org/en/latest/cops_style/#stylehashtransformkeys
   Enabled: false
 
 Style/HashTransformValues:

--- a/rubocop-airbnb/lib/rubocop/airbnb/version.rb
+++ b/rubocop-airbnb/lib/rubocop/airbnb/version.rb
@@ -3,6 +3,6 @@
 module RuboCop
   module Airbnb
     # Version information for the the Airbnb RuboCop plugin.
-    VERSION = '3.0.2'
+    VERSION = '4.0.0'
   end
 end

--- a/rubocop-airbnb/lib/rubocop/cop/airbnb/continuation_slash.rb
+++ b/rubocop-airbnb/lib/rubocop/cop/airbnb/continuation_slash.rb
@@ -14,7 +14,7 @@ module RuboCop
         alias on_send enforce_violation
         alias on_if enforce_violation
 
-        RuboCop::AST::Node::ASSIGNMENTS.each do |type|
+        ::RuboCop::AST::Node::ASSIGNMENTS.each do |type|
           define_method("on_#{type}") do |node|
             enforce_violation(node)
           end

--- a/rubocop-airbnb/rubocop-airbnb.gemspec
+++ b/rubocop-airbnb/rubocop-airbnb.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.license = 'MIT'
   spec.version = RuboCop::Airbnb::VERSION
   spec.platform = Gem::Platform::RUBY
-  spec.required_ruby_version = '>= 2.3'
+  spec.required_ruby_version = '>= 2.4'
 
   spec.require_paths = ['lib']
   spec.files = Dir[
@@ -25,9 +25,9 @@ Gem::Specification.new do |spec|
     'Gemfile',
   ]
 
-  spec.add_dependency('rubocop', '~> 0.80.0')
-  spec.add_dependency('rubocop-performance', '~> 1.5.0')
-  spec.add_dependency('rubocop-rails', '~> 2.4.2')
-  spec.add_dependency('rubocop-rspec', '~> 1.38.1')
+  spec.add_dependency('rubocop', '~> 0.93.1')
+  spec.add_dependency('rubocop-performance', '~> 1.10.2')
+  spec.add_dependency('rubocop-rails', '~> 2.9.1')
+  spec.add_dependency('rubocop-rspec', '~> 1.44.1')
   spec.add_development_dependency('rspec', '~> 3.5')
 end


### PR DESCRIPTION
Start working on (long awaited) ruby3.0 support; as copied from the changelog:
* Add support for Ruby 3.0
* Run CI against Ruby 2.7
* Drop support for Ruby 2.3
* Update rubocop to 0.93.1
