### PR TITLE
Relaxing rubocop dependencies

### DIFF
--- a/rubocop-airbnb/lib/rubocop/airbnb/version.rb
+++ b/rubocop-airbnb/lib/rubocop/airbnb/version.rb
@@ -3,6 +3,6 @@
 module RuboCop
   module Airbnb
     # Version information for the the Airbnb RuboCop plugin.
-    VERSION = '4.0.0'
+    VERSION = '4.0.1'
   end
 end

--- a/rubocop-airbnb/rubocop-airbnb.gemspec
+++ b/rubocop-airbnb/rubocop-airbnb.gemspec
@@ -25,9 +25,9 @@ Gem::Specification.new do |spec|
     'Gemfile',
   ]
 
-  spec.add_dependency('rubocop', '~> 0.93.1')
-  spec.add_dependency('rubocop-performance', '~> 1.10.2')
-  spec.add_dependency('rubocop-rails', '~> 2.9.1')
-  spec.add_dependency('rubocop-rspec', '~> 1.44.1')
+  spec.add_dependency('rubocop', '>= 0.93.1')
+  spec.add_dependency('rubocop-performance', '>= 1.10.2')
+  spec.add_dependency('rubocop-rails', '>= 2.9.1')
+  spec.add_dependency('rubocop-rspec', '>= 1.44.1')
   spec.add_development_dependency('rspec', '~> 3.5')
 end


### PR DESCRIPTION
Closes #184

Working with `rubocop-airbnb` has become difficult due to the version difference with their dependencies. 
This PR intends to relax dependencies in order to allow its usage with more up-to-date versions of rubocop libraries.

I hope it helps others as it helped me. 