### PR TITLE
Loose rubocop version constraint

### DIFF
--- a/rubocop-airbnb/lib/rubocop/airbnb/version.rb
+++ b/rubocop-airbnb/lib/rubocop/airbnb/version.rb
@@ -3,6 +3,6 @@
 module RuboCop
   module Airbnb
     # Version information for the the Airbnb RuboCop plugin.
-    VERSION = '5.0.0'
+    VERSION = '5.1.0'
   end
 end

--- a/rubocop-airbnb/rubocop-airbnb.gemspec
+++ b/rubocop-airbnb/rubocop-airbnb.gemspec
@@ -25,7 +25,10 @@ Gem::Specification.new do |spec|
     'Gemfile',
   ]
 
-  spec.add_dependency('rubocop', '~> 1.22.0')
+  # rubocop:disable Layout/LineLength
+  spec.add_dependency('rubocop', '>= 1.22.0', '< 1.32', '!= 1.29.0', '!= 1.29.1', '!= 1.30.0', '!= 1.30.1')
+  # rubocop:enable Layout/LineLength
+
   spec.add_dependency('rubocop-performance', '~> 1.10.2')
   spec.add_dependency('rubocop-rails', '~> 2.9.1')
   spec.add_dependency('rubocop-rspec', '~> 2.0.0')


### PR DESCRIPTION
### Why
-------------------
* Currently there's no way to run Rubocop's static code analysis with a target version below 2.5. This was fixed in Rubocop [version 1.30.0](https://github.com/rubocop/rubocop/blob/v1.32.0/CHANGELOG.md#bug-fixes-5). 
* As support for Ruby 2.5 was dropped in [1.29.0](https://github.com/rubocop/rubocop/blob/v1.32.0/CHANGELOG.md#changes-4), we cannot just bump Rubocop version, as it would be a breaking change.
* As `Lint/UselessElseWithoutRescue` was removed in 1.29.0 and added back in  1.31.0, we need to explicitly exclude those versions as we are making use of that Cop.

Therefore in order to support static code analysis and maintain support for currently supported Ruby versions, Rubocop version constraint must be loosen to reach 1.31, excluding the versions which are incompatible.
