### PR TITLE
Recover static analysis

### DIFF
--- a/.github/workflows/rspec_rubocop.yml
+++ b/.github/workflows/rspec_rubocop.yml
@@ -18,8 +18,6 @@ jobs:
     strategy:
       matrix:
         include: # use bundler 2.3 for ruby versions < 2.6 (https://bundler.io/compatibility.html)
-        - ruby-version: 2.5
-          bundler-version: 2.3
         - ruby-version: 2.6
           bundler-version: latest
         - ruby-version: 2.7

--- a/rubocop-airbnb/CHANGELOG.md
+++ b/rubocop-airbnb/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 6.0.0
+* Recover code analysis using `TargetRubyVersion` from Ruby 2.0 to 2.4
+* Drop support for Ruby 2.5
+* Update rubocop to 1.32.0
+
 # 5.0.0
 * Add support for Ruby 3.1
 * Drop support for Ruby 2.4

--- a/rubocop-airbnb/lib/rubocop/airbnb/version.rb
+++ b/rubocop-airbnb/lib/rubocop/airbnb/version.rb
@@ -3,6 +3,6 @@
 module RuboCop
   module Airbnb
     # Version information for the the Airbnb RuboCop plugin.
-    VERSION = '5.0.0'
+    VERSION = '6.0.0'
   end
 end

--- a/rubocop-airbnb/rubocop-airbnb.gemspec
+++ b/rubocop-airbnb/rubocop-airbnb.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
     'Gemfile',
   ]
 
-  spec.add_dependency('rubocop', '~> 1.22.0')
+  spec.add_dependency('rubocop', '~> 1.32.0')
   spec.add_dependency('rubocop-performance', '~> 1.10.2')
   spec.add_dependency('rubocop-rails', '~> 2.9.1')
   spec.add_dependency('rubocop-rspec', '~> 2.0.0')


### PR DESCRIPTION
#### Sumary
* Update rubocop to 1.32.0
* Recover code analysis using `TargetRubyVersion` from Ruby 2.0 to 2.4
* Drop support for Ruby 2.5
