### PR TITLE
Use `RESTRICT_ON_SEND`

### DIFF
--- a/rubocop-airbnb/lib/rubocop/cop/airbnb/default_scope.rb
+++ b/rubocop-airbnb/lib/rubocop/cop/airbnb/default_scope.rb
@@ -8,9 +8,10 @@ module RuboCop
               'refactor data access patterns since the scope becomes part '\
               'of every query unless explicitly excluded, even when it is '\
               'unnecessary or incidental to the desired logic.'.freeze
+        RESTRICT_ON_SEND = %i(default_scope).freeze
 
         def on_send(node)
-          return unless node.command?(:default_scope)
+          return if node.receiver
 
           add_offense(node)
         end

--- a/rubocop-airbnb/lib/rubocop/cop/airbnb/factory_class_use_string.rb
+++ b/rubocop-airbnb/lib/rubocop/cop/airbnb/factory_class_use_string.rb
@@ -6,9 +6,10 @@ module RuboCop
       class FactoryClassUseString < Base
         MSG = 'Instead of :class => MyClass, use :class => "MyClass". ' \
           "This enables faster spec startup time and faster Zeus reload time.".freeze
+        RESTRICT_ON_SEND = %i(factory).freeze
 
         def on_send(node)
-          return unless node.command?(:factory)
+          return if node.receiver
 
           class_pair = class_node(node)
 

--- a/rubocop-airbnb/lib/rubocop/cop/airbnb/mass_assignment_accessible_modifier.rb
+++ b/rubocop-airbnb/lib/rubocop/cop/airbnb/mass_assignment_accessible_modifier.rb
@@ -5,11 +5,9 @@ module RuboCop
       # mass assignment. It's a lazy, potentially dangerous approach that should be discouraged.
       class MassAssignmentAccessibleModifier < Base
         MSG = 'Do no override and objects mass assignment restrictions.'.freeze
+        RESTRICT_ON_SEND = %i(accessible=).freeze
 
         def on_send(node)
-          _receiver, method_name, *_args = *node
-
-          return unless method_name == :accessible=
           add_offense(node, message: MSG)
         end
       end

--- a/rubocop-airbnb/lib/rubocop/cop/airbnb/no_timeout.rb
+++ b/rubocop-airbnb/lib/rubocop/cop/airbnb/no_timeout.rb
@@ -8,9 +8,14 @@ module RuboCop
           'It can also cause logic errors since it can raise in ' \
           'any callee scope. Use client library timeouts and monitoring to ' \
           'ensure proper timing behavior for web requests.'.freeze
+        RESTRICT_ON_SEND = %i(timeout).freeze
+
+        def_node_matcher :timeout_const?, <<~PATTERN
+          (const {cbase nil?} :Timeout)
+        PATTERN
 
         def on_send(node)
-          return unless node.source.start_with?('Timeout.timeout')
+          return unless timeout_const?(node.receiver)
           add_offense(node, message: MSG)
         end
       end

--- a/rubocop-airbnb/lib/rubocop/cop/airbnb/phrase_bundle_keys.rb
+++ b/rubocop-airbnb/lib/rubocop/cop/airbnb/phrase_bundle_keys.rb
@@ -27,10 +27,11 @@ module RuboCop
       class PhraseBundleKeys < Base
         MESSAGE =
           'Phrase bundle keys should match their translation keys.'.freeze
+        RESTRICT_ON_SEND = %i(t).freeze
 
         def on_send(node)
           parent = node.parent
-          if t_call?(node) && in_phrase_bundle_class?(node) && parent.pair_type?
+          if in_phrase_bundle_class?(node) && parent.pair_type?
             hash_key = parent.children[0]
             unless hash_key.children[0] == node.children[2].children[0]
               add_offense(hash_key, message: MESSAGE)
@@ -56,10 +57,6 @@ module RuboCop
               e.const_type? &&
               e.children[1] == :PhraseBundle
           end
-        end
-
-        def t_call?(node)
-          node.children[1] == :t
         end
       end
     end

--- a/rubocop-airbnb/lib/rubocop/cop/airbnb/rspec_environment_modification.rb
+++ b/rubocop-airbnb/lib/rubocop/cop/airbnb/rspec_environment_modification.rb
@@ -40,6 +40,7 @@ module RuboCop
         def_node_matcher :rails_env_assignment, '(send (const nil? :Rails) :env= ...)'
 
         MESSAGE = "Do not stub or set Rails.env in specs. Use the `stub_env` method instead".freeze
+        RESTRICT_ON_SEND = %i(to stub env=).freeze
 
         def on_send(node)
           path = node.source_range.source_buffer.name

--- a/rubocop-airbnb/lib/rubocop/cop/airbnb/unsafe_yaml_marshal.rb
+++ b/rubocop-airbnb/lib/rubocop/cop/airbnb/unsafe_yaml_marshal.rb
@@ -6,35 +6,34 @@ module RuboCop
         MSG = 'Using unsafe YAML parsing methods on untrusted input can lead ' \
               'to remote code execution. Use `safe_load`, `parse`, `parse_file`, or ' \
               '`parse_stream` instead'.freeze
+        RESTRICT_ON_SEND = %i(load load_documents load_file load_stream).freeze
 
         def on_send(node)
-          receiver, method_name, *_args = *node
+          return if node.receiver.nil?
+          return unless node.receiver.const_type?
 
-          return if receiver.nil?
-          return unless receiver.const_type?
-
-          check_yaml(node, receiver, method_name, *_args)
-          check_marshal(node, receiver, method_name, *_args)
+          check_yaml(node)
+          check_marshal(node)
         rescue => e
           puts e
           puts e.backtrace
           raise
         end
 
-        def check_yaml(node, receiver, method_name, *_args)
-          return unless ['YAML', 'Psych'].include?(receiver.const_name)
-          return unless [:load, :load_documents, :load_file, :load_stream].include?(method_name)
+        def check_yaml(node)
+          const_name = node.receiver.const_name
+          return unless ['YAML', 'Psych'].include?(const_name)
 
-          message = "Using `#{receiver.const_name}.#{method_name}` on untrusted input can lead " \
+          message = "Using `#{const_name}.#{node.method_name}` on untrusted input can lead " \
             "to remote code execution. Use `safe_load`, `parse`, `parse_file`, or " \
             "`parse_stream` instead"
 
           add_offense(node, message: message)
         end
 
-        def check_marshal(node, receiver, method_name, *_args)
-          return unless receiver.const_name == 'Marshal'
-          return unless method_name == :load
+        def check_marshal(node)
+          return unless node.receiver.const_name == 'Marshal'
+          return unless node.method?(:load)
 
           message = 'Using `Marshal.load` on untrusted input can lead to remote code execution. ' \
             'Restructure your code to not use Marshal'

--- a/rubocop-airbnb/spec/rubocop/cop/airbnb/no_timeout_spec.rb
+++ b/rubocop-airbnb/spec/rubocop/cop/airbnb/no_timeout_spec.rb
@@ -11,6 +11,17 @@ describe RuboCop::Cop::Airbnb::NoTimeout, :config do
       RUBY
     end
 
+    it 'rejects ::Timeout.timeout' do
+      expect_offense(<<~RUBY)
+        def some_method(a)
+          ::Timeout.timeout(5) do
+          ^^^^^^^^^^^^^^^^^^^^ Do not use Timeout.timeout. [...]
+            some_other_method(a)
+          end
+        end
+      RUBY
+    end
+
     it 'accepts foo.timeout' do
       expect_no_offenses(<<~RUBY)
         def some_method(a)


### PR DESCRIPTION
Follow up https://github.com/rubocop-hq/rubocop/pull/8365.

This PR uses `RESTRICT_ON_SEND` to restrict callbacks `on_send` to specific method names only. https://docs.rubocop.org/rubocop/1.46/development.html#implementation