### PR TITLE
Use strings for ruby versions in github action

### DIFF
--- a/.github/workflows/rspec_rubocop.yml
+++ b/.github/workflows/rspec_rubocop.yml
@@ -18,13 +18,13 @@ jobs:
     strategy:
       matrix:
         include: # use bundler 2.3 for ruby versions < 2.6 (https://bundler.io/compatibility.html)
-        - ruby-version: 2.6
+        - ruby-version: '2.6'
           bundler-version: latest
-        - ruby-version: 2.7
+        - ruby-version: '2.7'
           bundler-version: latest
-        - ruby-version: 3.0
+        - ruby-version: '3.0'
           bundler-version: latest
-        - ruby-version: 3.1
+        - ruby-version: '3.1'
           bundler-version: latest
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Avoid `3.0` parsing as ruby 3 and installing 3.x, instead use `'3.0'` to fix the minor

https://github.com/airbnb/sparsam/pull/32/files#diff-2c17722b4a6987fd58e647624d32699831d319444edd32d7785afa5fd0f8cd14R35

cc @Umofomia 