### PR TITLE
Update to support ruby3.1

### DIFF
--- a/rubocop-airbnb/rubocop-airbnb.gemspec
+++ b/rubocop-airbnb/rubocop-airbnb.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency('rubocop', '~> 1.32.0')
   spec.add_dependency('rubocop-performance', '>= 1.10.2', '< 1.14' )
   spec.add_dependency('rubocop-rails', '>= 2.9.1', '< 2.14' )
-  spec.add_dependency('rubocop-rspec', '~> 2.0.0')
+  spec.add_dependency('rubocop-rspec', '>= 2.0', '<= 2.8')
   spec.add_development_dependency('rspec', '~> 3.5')
 end

--- a/rubocop-airbnb/rubocop-airbnb.gemspec
+++ b/rubocop-airbnb/rubocop-airbnb.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   ]
 
   spec.add_dependency('rubocop', '~> 1.32.0')
-  spec.add_dependency('rubocop-performance', '~> 1.10.2')
+  spec.add_dependency('rubocop-performance', '>= 1.10.2', '< 1.14' )
   spec.add_dependency('rubocop-rails', '~> 2.9.1')
   spec.add_dependency('rubocop-rspec', '~> 2.0.0')
   spec.add_development_dependency('rspec', '~> 3.5')

--- a/rubocop-airbnb/rubocop-airbnb.gemspec
+++ b/rubocop-airbnb/rubocop-airbnb.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency('rubocop', '~> 1.32.0')
   spec.add_dependency('rubocop-performance', '>= 1.10.2', '< 1.14' )
-  spec.add_dependency('rubocop-rails', '~> 2.9.1')
+  spec.add_dependency('rubocop-rails', '>= 2.9.1', '< 2.14' )
   spec.add_dependency('rubocop-rspec', '~> 2.0.0')
   spec.add_development_dependency('rspec', '~> 3.5')
 end


### PR DESCRIPTION
## Summary
- Update the dependencies in order for all of them to support (and be tested against) ruby 3.1.
- Also updated the `minimum ruby version` from `2.5` to `2.6` because `rubocop`'s minimum required ruby version is 2.6.

## Tested
Tested locally.