### PR TITLE
Support for `Ruby 3.3`

### DIFF
--- a/.github/workflows/rspec_rubocop.yml
+++ b/.github/workflows/rspec_rubocop.yml
@@ -26,6 +26,8 @@ jobs:
           bundler-version: latest
         - ruby-version: '3.1'
           bundler-version: latest
+        - ruby-version: '3.3'
+          bundler-version: latest
     steps:
     - uses: actions/checkout@v3
     - name: Set up Ruby

--- a/.github/workflows/rspec_rubocop.yml
+++ b/.github/workflows/rspec_rubocop.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Ruby
-      uses: ruby/setup-ruby@ee2113536afb7f793eed4ce60e8d3b26db912da4 # v1.127.0
+      uses: ruby/setup-ruby@2a9a743e19810b9f3c38060637daf594dbd7b37f # 1.186.0
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler: ${{ matrix.bundler-version }}

--- a/.github/workflows/rspec_rubocop.yml
+++ b/.github/workflows/rspec_rubocop.yml
@@ -18,8 +18,6 @@ jobs:
     strategy:
       matrix:
         include: # use bundler 2.3 for ruby versions < 2.6 (https://bundler.io/compatibility.html)
-        - ruby-version: '2.6'
-          bundler-version: latest
         - ruby-version: '2.7'
           bundler-version: latest
         - ruby-version: '3.0'

--- a/rubocop-airbnb/config/rubocop-style.yml
+++ b/rubocop-airbnb/config/rubocop-style.yml
@@ -116,7 +116,7 @@ Style/BlockDelimiters:
     - let!
     - subject
     - watch
-  IgnoredMethods:
+  AllowedMethods:
     # Methods that can be either procedural or functional and cannot be
     # categorised from their usage alone, e.g.
     #
@@ -889,7 +889,7 @@ Style/SymbolLiteral:
 Style/SymbolProc:
   Description: Use symbols as procs instead of blocks when possible.
   Enabled: false
-  IgnoredMethods:
+  AllowedMethods:
   - respond_to
 
 Style/TernaryParentheses:

--- a/rubocop-airbnb/rubocop-airbnb.gemspec
+++ b/rubocop-airbnb/rubocop-airbnb.gemspec
@@ -25,9 +25,9 @@ Gem::Specification.new do |spec|
     'Gemfile',
   ]
 
-  spec.add_dependency('rubocop', '~> 1.32.0')
-  spec.add_dependency('rubocop-performance', '~> 1.10.2')
-  spec.add_dependency('rubocop-rails', '~> 2.9.1')
-  spec.add_dependency('rubocop-rspec', '~> 2.0.0')
+  spec.add_dependency('rubocop', '~> 1.48.0')
+  spec.add_dependency('rubocop-performance', '~> 1.20.2')
+  spec.add_dependency('rubocop-rails', '~> 2.24.0')
+  spec.add_dependency('rubocop-rspec', '~> 2.26.0')
   spec.add_development_dependency('rspec', '~> 3.5')
 end

--- a/rubocop-airbnb/rubocop-airbnb.gemspec
+++ b/rubocop-airbnb/rubocop-airbnb.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
     'Gemfile',
   ]
 
-  spec.add_dependency('rubocop', '~> 1.48.0')
+  spec.add_dependency('rubocop', '~> 1.61.0')
   spec.add_dependency('rubocop-performance', '~> 1.20.2')
   spec.add_dependency('rubocop-rails', '~> 2.24.0')
   spec.add_dependency('rubocop-rspec', '~> 2.26.0')

--- a/rubocop-airbnb/rubocop-airbnb.gemspec
+++ b/rubocop-airbnb/rubocop-airbnb.gemspec
@@ -25,9 +25,9 @@ Gem::Specification.new do |spec|
     'Gemfile',
   ]
 
-  spec.add_dependency('rubocop', '~> 1.61.0')
-  spec.add_dependency('rubocop-performance', '~> 1.20.2')
-  spec.add_dependency('rubocop-rails', '~> 2.24.0')
-  spec.add_dependency('rubocop-rspec', '~> 2.26.0')
+  spec.add_dependency('rubocop', '~> 1.61')
+  spec.add_dependency('rubocop-performance', '~> 1.20')
+  spec.add_dependency('rubocop-rails', '~> 2.24')
+  spec.add_dependency('rubocop-rspec', '~> 2.26')
   spec.add_development_dependency('rspec', '~> 3.5')
 end

--- a/rubocop-airbnb/rubocop-airbnb.gemspec
+++ b/rubocop-airbnb/rubocop-airbnb.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
     'Gemfile',
   ]
 
-  spec.add_dependency('rubocop', '>= 1.61.0')
+  spec.add_dependency('rubocop', '~> 1.61.0')
   spec.add_dependency('rubocop-performance', '~> 1.20.2')
   spec.add_dependency('rubocop-rails', '~> 2.24.0')
   spec.add_dependency('rubocop-rspec', '~> 2.26.0')

--- a/rubocop-airbnb/rubocop-airbnb.gemspec
+++ b/rubocop-airbnb/rubocop-airbnb.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
     'Gemfile',
   ]
 
-  spec.add_dependency('rubocop', '~> 1.61.0')
+  spec.add_dependency('rubocop', '>= 1.61.0')
   spec.add_dependency('rubocop-performance', '~> 1.20.2')
   spec.add_dependency('rubocop-rails', '~> 2.24.0')
   spec.add_dependency('rubocop-rspec', '~> 2.26.0')

--- a/rubocop-airbnb/rubocop-airbnb.gemspec
+++ b/rubocop-airbnb/rubocop-airbnb.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.license = 'MIT'
   spec.version = RuboCop::Airbnb::VERSION
   spec.platform = Gem::Platform::RUBY
-  spec.required_ruby_version = '>= 2.5'
+  spec.required_ruby_version = '>= 2.7'
 
   spec.require_paths = ['lib']
   spec.files = Dir[


### PR DESCRIPTION
Add support for `Ruby 3.3`

Found that `rubocop-airbnb` requires `rubocop 1.32.0` which only supports up to `Ruby 3.2`, See [here](https://github.com/rubocop/rubocop/blame/v1.32.0/lib/rubocop/target_ruby.rb).
[This](https://github.com/rubocop/rubocop/commit/e8a997ad3e01c39659aee8c0d16ef4ede8fde966) is the commit that adds support for `3.3` starting from version `1.46.0`.

# Summary
- Update `rubocop` version to support `Ruby 3.3`
- Constrain `rubocop` version to be `>= 1.61.0` 
- Fixed some deprecations
- Added `Ruby 3.3` to the CI matrix

## Test
- Ran tests locally.
