### PR TITLE
Prepare for 7.0.0 release

### DIFF
--- a/rubocop-airbnb/CHANGELOG.md
+++ b/rubocop-airbnb/CHANGELOG.md
@@ -1,7 +1,12 @@
+# 7.0.0
+* Add support for Ruby 3.3
+* Drop support for Ruby 2.6
+* Update rubocop to ~> 1.61
+
 # 6.0.0
 * Recover code analysis using `TargetRubyVersion` from Ruby 2.0 to 2.4
 * Drop support for Ruby 2.5
-* Update rubocop to 1.32.0
+* Update rubocop to ~> 1.32.0
 
 # 5.0.0
 * Add support for Ruby 3.1

--- a/rubocop-airbnb/lib/rubocop/airbnb/version.rb
+++ b/rubocop-airbnb/lib/rubocop/airbnb/version.rb
@@ -3,6 +3,6 @@
 module RuboCop
   module Airbnb
     # Version information for the the Airbnb RuboCop plugin.
-    VERSION = '6.0.0'
+    VERSION = '7.0.0'
   end
 end


### PR DESCRIPTION
* Add support for Ruby 3.3
* Drop support for Ruby 2.6
* Update rubocop to ~> 1.61