### PR TITLE
Removing warning caused by Cops having a wrong namespace

### DIFF
--- a/rubocop-airbnb/CHANGELOG.md
+++ b/rubocop-airbnb/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased changes
+- Fix cops with the wrong namespace
+
 # 7.0.0
 * Add support for Ruby 3.3
 * Drop support for Ruby 2.6

--- a/rubocop-airbnb/config/rubocop-rspec.yml
+++ b/rubocop-airbnb/config/rubocop-rspec.yml
@@ -309,7 +309,7 @@ RSpec/VoidExpect:
   Description: This cop checks void `expect()`.
   Enabled: false
 
-RSpec/Capybara/CurrentPathExpectation:
+Capybara/CurrentPathExpectation:
   Description: Checks that no expectations are set on Capybara's `current_path`.
   Enabled: false
 
@@ -317,10 +317,10 @@ RSpec/Capybara/FeatureMethods:
   Description: Checks for consistent method usage in feature specs.
   Enabled: false
 
-RSpec/FactoryBot/AttributeDefinedStatically:
+FactoryBot/AttributeDefinedStatically:
   Description: Always declare attribute values as blocks.
   Enabled: false
 
-RSpec/FactoryBot/CreateList:
+FactoryBot/CreateList:
   Description: Checks for create_list usage.
   Enabled: true


### PR DESCRIPTION
## Summary

As part of the PR for [adding support for Ruby 3.3](https://github.com/airbnb/ruby/pull/205) we bumped the `rubocop-rspec` dependency to `~> 2.26`, which depends on `rubocop-capybara` `~> 2.17` and `rubocop-factory_bot` `~> 2.22`. 

On those versions, the `RSpec` namespace was removed from their cops hence a warning was being logged when running `rubocop` with the last version of this gem.

Related PRs:
- https://github.com/rubocop/rubocop-factory_bot/commit/812771eb33453e40f51c7a1cc993d7c8b6f5b33a
- https://github.com/rubocop/rubocop-capybara/commit/e36f30457b6a49d1e04847d2337186dc0d03a435