### PR TITLE
Release v8.0.0

### DIFF
--- a/rubocop-airbnb/CHANGELOG.md
+++ b/rubocop-airbnb/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 8.0.0
+* [#72](https://github.com/airbnb/ruby/pull/212) Adopt Rubocop's plugin system (thanks @koic!)
+* Bump minimum gem versions:
+  * `rubocop` from `'~> 1.61'` to `'~> 1.72'`
+  * `rubocop-performance` from `'~> 1.20'` to `'~> 1.24'`
+  * `rubocop-rails` from `'~> 2.24'` to `'~> 2.30'`
+  * `rubocop-rspec` from `'~> 2.26'` to `'~> 3.5'`
+* Add explicit `rubocop-*` gem dependencies which have been extracted
+  * `rubocop-capybara` with min version `'~> 2.22'`
+  * `rubocop-factory_bot` with min version `'~> 2.27'`
+
 # 7.0.0
 * Add support for Ruby 3.3
 * Drop support for Ruby 2.6

--- a/rubocop-airbnb/lib/rubocop/airbnb/version.rb
+++ b/rubocop-airbnb/lib/rubocop/airbnb/version.rb
@@ -3,6 +3,6 @@
 module RuboCop
   module Airbnb
     # Version information for the the Airbnb RuboCop plugin.
-    VERSION = '7.0.0'
+    VERSION = '8.0.0'
   end
 end


### PR DESCRIPTION
Release v8.0.0 to adopt Rubocop's plugin system. See https://github.com/airbnb/ruby/pull/212 – thanks @koic !

It's _possible_ this doesn't need to be a major release due to the fact that _likely_ many of these changes are backwards compatible, but I haven't done a thorough analysis of breaking changes in the available cops, and at the very least we now have a major version bump for the minimum allowed version of `rubocop-rspec` from the 2.x to 3.x branch.