### PR TITLE
Fix warnings after `Naming/PredicateName` was renamed to `Naming/PredicatePrefix`

### DIFF
--- a/rubocop-airbnb/CHANGELOG.md
+++ b/rubocop-airbnb/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+* Fix warnings after `Naming/PredicateName` was renamed to `Naming/PredicatePrefix` in `rubocop` `v1.76.0`
+* Bump `rubocop` minimum required version from `~> 1.72` to `~> 1.76`
+
 # 8.0.0
 * [#72](https://github.com/airbnb/ruby/pull/212) Adopt Rubocop's plugin system (thanks @koic!)
 * Bump minimum gem versions:

--- a/rubocop-airbnb/config/rubocop-naming.yml
+++ b/rubocop-airbnb/config/rubocop-naming.yml
@@ -47,7 +47,7 @@ Naming/MethodName:
   - snake_case
   - camelCase
 
-Naming/PredicateName:
+Naming/PredicatePrefix:
   Description: Check the names of predicate methods.
   StyleGuide: https://github.com/rubocop-hq/ruby-style-guide#bool-methods-qmark
   Enabled: false

--- a/rubocop-airbnb/rubocop-airbnb.gemspec
+++ b/rubocop-airbnb/rubocop-airbnb.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.metadata['default_lint_roller_plugin'] = 'RuboCop::Airbnb::Plugin'
 
   spec.add_dependency('lint_roller', '~> 1.1')
-  spec.add_dependency('rubocop', '~> 1.72')
+  spec.add_dependency('rubocop', '~> 1.76')
   spec.add_dependency('rubocop-capybara', '~> 2.22')
   spec.add_dependency('rubocop-factory_bot', '~> 2.27')
   spec.add_dependency('rubocop-performance', '~> 1.24')


### PR DESCRIPTION
Fixes https://github.com/airbnb/ruby/issues/215.