### PR TITLE
v8.1.0 release

### DIFF
--- a/rubocop-airbnb/CHANGELOG.md
+++ b/rubocop-airbnb/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Unreleased
-* Fix warnings after `Naming/PredicateName` was renamed to `Naming/PredicatePrefix` in `rubocop` `v1.76.0`
-* Bump `rubocop` minimum required version from `~> 1.72` to `~> 1.76`
+
+# 8.1.0
+* [#216](https://github.com/airbnb/ruby/pull/216) handle renamed cop (thanks @santiagorodriguez96!)
+  * Fix warnings after `Naming/PredicateName` was renamed to `Naming/PredicatePrefix` in `rubocop` `v1.76.0`
+  * Bump `rubocop` minimum required version from `~> 1.72` to `~> 1.76`
 
 # 8.0.0
 * [#72](https://github.com/airbnb/ruby/pull/212) Adopt Rubocop's plugin system (thanks @koic!)

--- a/rubocop-airbnb/lib/rubocop/airbnb/version.rb
+++ b/rubocop-airbnb/lib/rubocop/airbnb/version.rb
@@ -3,6 +3,6 @@
 module RuboCop
   module Airbnb
     # Version information for the the Airbnb RuboCop plugin.
-    VERSION = '8.0.0'
+    VERSION = '8.1.0'
   end
 end


### PR DESCRIPTION
# 8.1.0
* [#216](https://github.com/airbnb/ruby/pull/216) handle renamed cop (thanks @santiagorodriguez96!)
  * Fix warnings after `Naming/PredicateName` was renamed to `Naming/PredicatePrefix` in `rubocop` `v1.76.0`
  * Bump `rubocop` minimum required version from `~> 1.72` to `~> 1.76`