### PR TITLE
Rename Capybara/CurrentPathExpectation configuration

### DIFF
--- a/rubocop-airbnb/config/rubocop-capybara.yml
+++ b/rubocop-airbnb/config/rubocop-capybara.yml
@@ -1,6 +1,6 @@
 plugins:
   - rubocop-capybara
 
-Capybara/CurrentPathExpectation:
+Capybara/RSpec/CurrentPathExpectation:
   Description: Checks that no expectations are set on Capybara's `current_path`.
   Enabled: false


### PR DESCRIPTION
Closes #211

Rename `Capybara/CurrentPathExpectation` configuration to `Capybara/RSpec/CurrentPathExpectation` to resolve the following error with `rubocop-airbnb 8.1.0` and `rubocop-capybara 2.23.0`...
```
Error: The `Capybara/CurrentPathExpectation` cop has been moved to `Capybara/RSpec/CurrentPathExpectation`.
(obsolete configuration found in /Users/USERNAME/.rbenv/versions/3.2.11/lib/ruby/gems/3.2.0/gems/rubocop-airbnb-8.1.0/config/rubocop-capybara.yml, please update it)
```