### PR TITLE
Rename Lint/MissingCopEnableDirective obsolete parameter

### DIFF
--- a/rubocop-airbnb/config/rubocop-lint.yml
+++ b/rubocop-airbnb/config/rubocop-lint.yml
@@ -136,7 +136,7 @@ Lint/MissingCopEnableDirective:
   #   a = 1
   #   # rubocop:enable SomeCop
   # .inf for any size
-  MaximumRangeSize: .inf
+  MaxRangeSize: .inf
   Description: 'Checks for a `# rubocop:enable` after `# rubocop:disable`'
   Enabled: true
 


### PR DESCRIPTION
Rename obsolete parameter `MaximumRangeSize` (for `Lint/MissingCopEnableDirective`) to `MaxRangeSize` to resolve the following warning...
```
Warning: obsolete parameter `MaximumRangeSize` (for `Lint/MissingCopEnableDirective`) found in /Users/timowill/.rbenv/versions/3.2.11/lib/ruby/gems/3.2.0/gems/rubocop-airbnb-8.1.0/config/rubocop-lint.yml
`MaximumRangeSize` has been renamed to `MaxRangeSize`.
Warning: Lint/MissingCopEnableDirective does not support MaximumRangeSize parameter.

Supported parameters are:

  - Enabled
  - MaxRangeSize
```